### PR TITLE
refact: convert Value methods to use pointer receivers

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -14,29 +14,29 @@ type Atom struct {
 }
 
 // Free decrements the reference count of the atom.
-func (a Atom) Free() {
+func (a *Atom) Free() {
 	C.JS_FreeAtom(a.ctx.ref, a.ref)
 }
 
 // String returns the string representation of the atom.
-func (a Atom) String() string {
+func (a *Atom) String() string {
 	ptr := C.JS_AtomToCString(a.ctx.ref, a.ref)
 	defer C.JS_FreeCString(a.ctx.ref, ptr)
 	return C.GoString(ptr)
 }
 
 // Value returns the value representation of the atom.
-func (a Atom) Value() Value {
-	return Value{ctx: a.ctx, ref: C.JS_AtomToValue(a.ctx.ref, a.ref)}
+func (a *Atom) Value() *Value {
+	return &Value{ctx: a.ctx, ref: C.JS_AtomToValue(a.ctx.ref, a.ref)}
 }
 
 // propertyEnum is a wrapper around JSAtom for property enumeration.
 type propertyEnum struct {
 	IsEnumerable bool
-	atom         Atom
+	atom         *Atom
 }
 
 // String returns the atom string representation of the property.
-func (p propertyEnum) String() string {
+func (p *propertyEnum) String() string {
 	return p.atom.String()
 }

--- a/atom_test.go
+++ b/atom_test.go
@@ -71,7 +71,7 @@ func TestAtomSpecialCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var atom Atom
+			var atom *Atom
 
 			switch v := tc.input.(type) {
 			case string:
@@ -112,7 +112,7 @@ func TestAtomMemoryManagement(t *testing.T) {
 	}
 
 	// Test creating atoms with different names
-	atoms := make([]Atom, 50)
+	atoms := make([]*Atom, 50)
 	for i := 0; i < 50; i++ {
 		atoms[i] = ctx.Atom("property" + string(rune('A'+i%26)))
 	}
@@ -195,7 +195,7 @@ func TestAtomDeduplication(t *testing.T) {
 
 	// Test creating many atoms with the same name
 	sameName := "duplicateName"
-	atoms := make([]Atom, 50)
+	atoms := make([]*Atom, 50)
 
 	for i := 0; i < 50; i++ {
 		atoms[i] = ctx.Atom(sameName)

--- a/atom_test.go
+++ b/atom_test.go
@@ -21,7 +21,7 @@ func TestAtomBasics(t *testing.T) {
 
 	require.EqualValues(t, "testProperty", atom.String())
 
-	// Test Value method
+	// Test Value method - now returns *Value
 	atomValue := atom.Value()
 	defer atomValue.Free()
 	require.True(t, atomValue.IsString())
@@ -83,7 +83,7 @@ func TestAtomSpecialCases(t *testing.T) {
 			defer atom.Free()
 			require.EqualValues(t, tc.expected, atom.String())
 
-			// Test Value conversion
+			// Test Value conversion - now returns *Value
 			atomValue := atom.Value()
 			defer atomValue.Free()
 			require.EqualValues(t, tc.expected, atomValue.String())
@@ -146,7 +146,7 @@ func TestAtomWithObjects(t *testing.T) {
 
 	// Test setting and getting properties using atoms
 	propNames := []string{"name", "value", "flag", "data"}
-	propValues := []Value{
+	propValues := []*Value{ // MODIFIED: now uses *Value slice
 		ctx.String("test"),
 		ctx.Int32(42),
 		ctx.Bool(true),

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -16,8 +16,8 @@ func TestBridgeGetContextFromJSReturnNil(t *testing.T) {
 		defer rt.Close()
 		ctx := rt.NewContext()
 
-		// Create function and store it globally
-		fn := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		// Create function and store it globally - MODIFIED: now uses pointer signature
+		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			return ctx.String("test")
 		})
 		ctx.Globals().Set("testFn", fn)
@@ -109,8 +109,8 @@ func TestBridgeContextNotFound(t *testing.T) {
 		ctx := rt.NewContext()
 		defer ctx.Close()
 
-		// Create function and store it in JavaScript
-		fn := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		// Create function and store it in JavaScript - MODIFIED: now uses pointer signature
+		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			return ctx.String("test")
 		})
 		ctx.Globals().Set("testFunc", fn)
@@ -158,8 +158,8 @@ func TestBridgeFunctionNotFoundInHandleStore(t *testing.T) {
 		ctx := rt.NewContext()
 		defer ctx.Close()
 
-		// Create function and store it in JavaScript
-		fn := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		// Create function and store it in JavaScript - MODIFIED: now uses pointer signature
+		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			return ctx.String("test")
 		})
 		ctx.Globals().Set("testFunc", fn)
@@ -204,8 +204,8 @@ func TestBridgeInvalidFunctionType(t *testing.T) {
 		ctx := rt.NewContext()
 		defer ctx.Close()
 
-		// Create function and store it in JavaScript
-		fn := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		// Create function and store it in JavaScript - MODIFIED: now uses pointer signature
+		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			return ctx.String("test")
 		})
 		ctx.Globals().Set("testFunc", fn)
@@ -268,7 +268,7 @@ func TestBridgeClassConstructorErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				// SCHEME C: Return Go object for automatic association
 				return &Point{X: 1, Y: 2}, nil
 			}).
@@ -315,7 +315,7 @@ func TestBridgeClassConstructorErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				// SCHEME C: Return Go object for automatic association
 				return &Point{X: 1, Y: 2}, nil
 			}).
@@ -354,7 +354,7 @@ func TestBridgeClassConstructorErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				// SCHEME C: Return Go object for automatic association
 				return &Point{X: 1, Y: 2}, nil
 			}).
@@ -413,7 +413,7 @@ func TestBridgeClassConstructorErrors(t *testing.T) {
 
 		// Create class with constructor
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
 			Build(ctx)
@@ -453,7 +453,7 @@ func TestBridgeClassConstructorErrors(t *testing.T) {
 
 		// Create class with instance properties
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
 			Property("version", ctx.String("1.0.0")).
@@ -493,10 +493,10 @@ func TestBridgeClassMethodErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Method("testMethod", func(ctx *Context, this Value, args []Value) Value {
+			Method("testMethod", func(ctx *Context, this *Value, args []*Value) *Value {
 				return ctx.String("method called")
 			}).
 			Build(ctx)
@@ -547,10 +547,10 @@ func TestBridgeClassMethodErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Method("testMethod", func(ctx *Context, this Value, args []Value) Value {
+			Method("testMethod", func(ctx *Context, this *Value, args []*Value) *Value {
 				return ctx.String("method called")
 			}).
 			Build(ctx)
@@ -598,10 +598,10 @@ func TestBridgeClassMethodErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Method("testMethod", func(ctx *Context, this Value, args []Value) Value {
+			Method("testMethod", func(ctx *Context, this *Value, args []*Value) *Value {
 				return ctx.String("method called")
 			}).
 			Build(ctx)
@@ -693,10 +693,10 @@ func TestBridgeClassGetterErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Accessor("testProp", func(ctx *Context, this Value) Value {
+			Accessor("testProp", func(ctx *Context, this *Value) *Value {
 				return ctx.String("getter called")
 			}, nil).
 			Build(ctx)
@@ -747,10 +747,10 @@ func TestBridgeClassGetterErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Accessor("testProp", func(ctx *Context, this Value) Value {
+			Accessor("testProp", func(ctx *Context, this *Value) *Value {
 				return ctx.String("getter called")
 			}, nil).
 			Build(ctx)
@@ -798,10 +798,10 @@ func TestBridgeClassGetterErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Accessor("testProp", func(ctx *Context, this Value) Value {
+			Accessor("testProp", func(ctx *Context, this *Value) *Value {
 				return ctx.String("getter called")
 			}, nil).
 			Build(ctx)
@@ -893,10 +893,10 @@ func TestBridgeClassSetterErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Accessor("testProp", nil, func(ctx *Context, this Value, value Value) Value {
+			Accessor("testProp", nil, func(ctx *Context, this *Value, value *Value) *Value {
 				return ctx.Undefined()
 			}).
 			Build(ctx)
@@ -948,10 +948,10 @@ func TestBridgeClassSetterErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Accessor("testProp", nil, func(ctx *Context, this Value, value Value) Value {
+			Accessor("testProp", nil, func(ctx *Context, this *Value, value *Value) *Value {
 				return ctx.Undefined()
 			}).
 			Build(ctx)
@@ -1000,10 +1000,10 @@ func TestBridgeClassSetterErrors(t *testing.T) {
 
 		// MODIFIED FOR SCHEME C: Create class with new constructor signature
 		constructor, _, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
-			Accessor("testProp", nil, func(ctx *Context, this Value, value Value) Value {
+			Accessor("testProp", nil, func(ctx *Context, this *Value, value *Value) *Value {
 				return ctx.Undefined()
 			}).
 			Build(ctx)
@@ -1107,7 +1107,7 @@ func TestBridgeClassFinalizerContextIteration(t *testing.T) {
 		// Create classes in all contexts
 		for i, ctx := range []*Context{ctx1, ctx2, ctx3} {
 			constructor, _, err := NewClassBuilder(fmt.Sprintf("TestClass%d", i)).
-				Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+				Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 					// MODIFIED FOR SCHEME C: Return Go object for automatic association
 					// Create a simple object that implements finalizer
 					obj := &Point{X: float64(i), Y: float64(i)}
@@ -1145,7 +1145,7 @@ func TestBridgeCreateClassInstanceEdgeCases(t *testing.T) {
 
 		// Create class without instance properties
 		constructor, _, err := NewClassBuilder("NoPropsClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
 			Build(ctx)
@@ -1173,7 +1173,7 @@ func TestBridgeCreateClassInstanceEdgeCases(t *testing.T) {
 
 		// Create class with many instance properties
 		builder := NewClassBuilder("ManyPropsClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			})
 
@@ -1213,7 +1213,7 @@ func TestBridgeCreateClassInstanceFailures(t *testing.T) {
 
 		// Create class
 		constructor, originalClassID, err := NewClassBuilder("TestClass").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				return &Point{X: 1, Y: 2}, nil
 			}).
 			Build(ctx)

--- a/context.go
+++ b/context.go
@@ -334,15 +334,15 @@ func (ctx *Context) SetInterruptHandler(handler InterruptHandler) {
 }
 
 // Atom returns a new Atom value with given string.
-func (ctx *Context) Atom(v string) Atom {
+func (ctx *Context) Atom(v string) *Atom {
 	ptr := C.CString(v)
 	defer C.free(unsafe.Pointer(ptr))
-	return Atom{ctx: ctx, ref: C.JS_NewAtom(ctx.ref, ptr)}
+	return &Atom{ctx: ctx, ref: C.JS_NewAtom(ctx.ref, ptr)}
 }
 
-// Atom returns a new Atom value with given idx.
-func (ctx *Context) AtomIdx(idx uint32) Atom {
-	return Atom{ctx: ctx, ref: C.JS_NewAtomUInt32(ctx.ref, C.uint32_t(idx))}
+// AtomIdx returns a new Atom value with given idx.
+func (ctx *Context) AtomIdx(idx uint32) *Atom {
+	return &Atom{ctx: ctx, ref: C.JS_NewAtomUInt32(ctx.ref, C.uint32_t(idx))}
 }
 
 // Invoke invokes a function with given this value and arguments.

--- a/context.go
+++ b/context.go
@@ -43,84 +43,84 @@ func (ctx *Context) Close() {
 }
 
 // Null return a null value.
-func (ctx *Context) Null() Value {
-	return Value{ctx: ctx, ref: C.JS_NewNull()}
+func (ctx *Context) Null() *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewNull()}
 }
 
 // Undefined return a undefined value.
-func (ctx *Context) Undefined() Value {
-	return Value{ctx: ctx, ref: C.JS_NewUndefined()}
+func (ctx *Context) Undefined() *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewUndefined()}
 }
 
 // Uninitialized returns a uninitialized value.
-func (ctx *Context) Uninitialized() Value {
-	return Value{ctx: ctx, ref: C.JS_NewUninitialized()}
+func (ctx *Context) Uninitialized() *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewUninitialized()}
 }
 
 // Error returns a new exception value with given message.
-func (ctx *Context) Error(err error) Value {
-	val := Value{ctx: ctx, ref: C.JS_NewError(ctx.ref)}
+func (ctx *Context) Error(err error) *Value {
+	val := &Value{ctx: ctx, ref: C.JS_NewError(ctx.ref)}
 	val.Set("message", ctx.String(err.Error()))
 	return val
 }
 
 // Bool returns a bool value with given bool.
-func (ctx *Context) Bool(b bool) Value {
+func (ctx *Context) Bool(b bool) *Value {
 	bv := 0
 	if b {
 		bv = 1
 	}
-	return Value{ctx: ctx, ref: C.JS_NewBool(ctx.ref, C.int(bv))}
+	return &Value{ctx: ctx, ref: C.JS_NewBool(ctx.ref, C.int(bv))}
 }
 
 // Int32 returns a int32 value with given int32.
-func (ctx *Context) Int32(v int32) Value {
-	return Value{ctx: ctx, ref: C.JS_NewInt32(ctx.ref, C.int32_t(v))}
+func (ctx *Context) Int32(v int32) *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewInt32(ctx.ref, C.int32_t(v))}
 }
 
 // Int64 returns a int64 value with given int64.
-func (ctx *Context) Int64(v int64) Value {
-	return Value{ctx: ctx, ref: C.JS_NewInt64(ctx.ref, C.int64_t(v))}
+func (ctx *Context) Int64(v int64) *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewInt64(ctx.ref, C.int64_t(v))}
 }
 
 // Uint32 returns a uint32 value with given uint32.
-func (ctx *Context) Uint32(v uint32) Value {
-	return Value{ctx: ctx, ref: C.JS_NewUint32(ctx.ref, C.uint32_t(v))}
+func (ctx *Context) Uint32(v uint32) *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewUint32(ctx.ref, C.uint32_t(v))}
 }
 
 // BigInt64 returns a int64 value with given uint64.
-func (ctx *Context) BigInt64(v int64) Value {
-	return Value{ctx: ctx, ref: C.JS_NewBigInt64(ctx.ref, C.int64_t(v))}
+func (ctx *Context) BigInt64(v int64) *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewBigInt64(ctx.ref, C.int64_t(v))}
 }
 
 // BigUint64 returns a uint64 value with given uint64.
-func (ctx *Context) BigUint64(v uint64) Value {
-	return Value{ctx: ctx, ref: C.JS_NewBigUint64(ctx.ref, C.uint64_t(v))}
+func (ctx *Context) BigUint64(v uint64) *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewBigUint64(ctx.ref, C.uint64_t(v))}
 }
 
 // Float64 returns a float64 value with given float64.
-func (ctx *Context) Float64(v float64) Value {
-	return Value{ctx: ctx, ref: C.JS_NewFloat64(ctx.ref, C.double(v))}
+func (ctx *Context) Float64(v float64) *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewFloat64(ctx.ref, C.double(v))}
 }
 
 // String returns a string value with given string.
-func (ctx *Context) String(v string) Value {
+func (ctx *Context) String(v string) *Value {
 	ptr := C.CString(v)
 	defer C.free(unsafe.Pointer(ptr))
-	return Value{ctx: ctx, ref: C.JS_NewString(ctx.ref, ptr)}
+	return &Value{ctx: ctx, ref: C.JS_NewString(ctx.ref, ptr)}
 }
 
 // ArrayBuffer returns a ArrayBuffer value with given binary data.
-func (ctx *Context) ArrayBuffer(binaryData []byte) Value {
+func (ctx *Context) ArrayBuffer(binaryData []byte) *Value {
 	if len(binaryData) == 0 {
-		return Value{ctx: ctx, ref: C.JS_NewArrayBufferCopy(ctx.ref, nil, 0)}
+		return &Value{ctx: ctx, ref: C.JS_NewArrayBufferCopy(ctx.ref, nil, 0)}
 	}
-	return Value{ctx: ctx, ref: C.JS_NewArrayBufferCopy(ctx.ref, (*C.uchar)(&binaryData[0]), C.size_t(len(binaryData)))}
+	return &Value{ctx: ctx, ref: C.JS_NewArrayBufferCopy(ctx.ref, (*C.uchar)(&binaryData[0]), C.size_t(len(binaryData)))}
 }
 
 // createTypedArray is a helper function to create TypedArray with given data and type.
 // It creates an ArrayBuffer first, then constructs a TypedArray from it.
-func (ctx *Context) createTypedArray(data unsafe.Pointer, elementCount int, elementSize int, arrayType C.JSTypedArrayEnum) Value {
+func (ctx *Context) createTypedArray(data unsafe.Pointer, elementCount int, elementSize int, arrayType C.JSTypedArrayEnum) *Value {
 	// Calculate total bytes needed for the data
 	totalBytes := elementCount * elementSize
 
@@ -140,14 +140,14 @@ func (ctx *Context) createTypedArray(data unsafe.Pointer, elementCount int, elem
 
 	// Pack arguments for JS_NewTypedArray call
 	args := []C.JSValue{buffer.ref, offset, length}
-	return Value{
+	return &Value{
 		ctx: ctx,
 		ref: C.JS_NewTypedArray(ctx.ref, C.int(len(args)), &args[0], arrayType),
 	}
 }
 
 // Int8Array returns a Int8Array value with given int8 slice.
-func (ctx *Context) Int8Array(data []int8) Value {
+func (ctx *Context) Int8Array(data []int8) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 1, C.JSTypedArrayEnum(C.GetTypedArrayInt8()))
 	}
@@ -155,7 +155,7 @@ func (ctx *Context) Int8Array(data []int8) Value {
 }
 
 // Uint8Array returns a Uint8Array value with given uint8 slice.
-func (ctx *Context) Uint8Array(data []uint8) Value {
+func (ctx *Context) Uint8Array(data []uint8) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 1, C.JSTypedArrayEnum(C.GetTypedArrayUint8()))
 	}
@@ -163,7 +163,7 @@ func (ctx *Context) Uint8Array(data []uint8) Value {
 }
 
 // Uint8ClampedArray returns a Uint8ClampedArray value with given uint8 slice.
-func (ctx *Context) Uint8ClampedArray(data []uint8) Value {
+func (ctx *Context) Uint8ClampedArray(data []uint8) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 1, C.JSTypedArrayEnum(C.GetTypedArrayUint8C()))
 	}
@@ -171,7 +171,7 @@ func (ctx *Context) Uint8ClampedArray(data []uint8) Value {
 }
 
 // Int16Array returns a Int16Array value with given int16 slice.
-func (ctx *Context) Int16Array(data []int16) Value {
+func (ctx *Context) Int16Array(data []int16) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 2, C.JSTypedArrayEnum(C.GetTypedArrayInt16()))
 	}
@@ -179,7 +179,7 @@ func (ctx *Context) Int16Array(data []int16) Value {
 }
 
 // Uint16Array returns a Uint16Array value with given uint16 slice.
-func (ctx *Context) Uint16Array(data []uint16) Value {
+func (ctx *Context) Uint16Array(data []uint16) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 2, C.JSTypedArrayEnum(C.GetTypedArrayUint16()))
 	}
@@ -187,7 +187,7 @@ func (ctx *Context) Uint16Array(data []uint16) Value {
 }
 
 // Int32Array returns a Int32Array value with given int32 slice.
-func (ctx *Context) Int32Array(data []int32) Value {
+func (ctx *Context) Int32Array(data []int32) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 4, C.JSTypedArrayEnum(C.GetTypedArrayInt32()))
 	}
@@ -195,7 +195,7 @@ func (ctx *Context) Int32Array(data []int32) Value {
 }
 
 // Uint32Array returns a Uint32Array value with given uint32 slice.
-func (ctx *Context) Uint32Array(data []uint32) Value {
+func (ctx *Context) Uint32Array(data []uint32) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 4, C.JSTypedArrayEnum(C.GetTypedArrayUint32()))
 	}
@@ -203,7 +203,7 @@ func (ctx *Context) Uint32Array(data []uint32) Value {
 }
 
 // Float32Array returns a Float32Array value with given float32 slice.
-func (ctx *Context) Float32Array(data []float32) Value {
+func (ctx *Context) Float32Array(data []float32) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 4, C.JSTypedArrayEnum(C.GetTypedArrayFloat32()))
 	}
@@ -211,7 +211,7 @@ func (ctx *Context) Float32Array(data []float32) Value {
 }
 
 // Float64Array returns a Float64Array value with given float64 slice.
-func (ctx *Context) Float64Array(data []float64) Value {
+func (ctx *Context) Float64Array(data []float64) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 8, C.JSTypedArrayEnum(C.GetTypedArrayFloat64()))
 	}
@@ -219,7 +219,7 @@ func (ctx *Context) Float64Array(data []float64) Value {
 }
 
 // BigInt64Array returns a BigInt64Array value with given int64 slice.
-func (ctx *Context) BigInt64Array(data []int64) Value {
+func (ctx *Context) BigInt64Array(data []int64) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 8, C.JSTypedArrayEnum(C.GetTypedArrayBigInt64()))
 	}
@@ -227,7 +227,7 @@ func (ctx *Context) BigInt64Array(data []int64) Value {
 }
 
 // BigUint64Array returns a BigUint64Array value with given uint64 slice.
-func (ctx *Context) BigUint64Array(data []uint64) Value {
+func (ctx *Context) BigUint64Array(data []uint64) *Value {
 	if len(data) == 0 {
 		return ctx.createTypedArray(nil, 0, 8, C.JSTypedArrayEnum(C.GetTypedArrayBigUint64()))
 	}
@@ -235,28 +235,28 @@ func (ctx *Context) BigUint64Array(data []uint64) Value {
 }
 
 // Object returns a new object value.
-func (ctx *Context) Object() Value {
-	return Value{ctx: ctx, ref: C.JS_NewObject(ctx.ref)}
+func (ctx *Context) Object() *Value {
+	return &Value{ctx: ctx, ref: C.JS_NewObject(ctx.ref)}
 }
 
 // ParseJson parses given json string and returns a object value.
-func (ctx *Context) ParseJSON(v string) Value {
+func (ctx *Context) ParseJSON(v string) *Value {
 	ptr := C.CString(v)
 	defer C.free(unsafe.Pointer(ptr))
 
 	filenamePtr := C.CString("")
 	defer C.free(unsafe.Pointer(filenamePtr))
 
-	return Value{ctx: ctx, ref: C.JS_ParseJSON(ctx.ref, ptr, C.size_t(len(v)), filenamePtr)}
+	return &Value{ctx: ctx, ref: C.JS_ParseJSON(ctx.ref, ptr, C.size_t(len(v)), filenamePtr)}
 }
 
 // Function returns a js function value with given function template
 // New implementation using HandleStore and JS_NewCFunction2 with magic parameter
-func (ctx *Context) Function(fn func(*Context, Value, []Value) Value) Value {
+func (ctx *Context) Function(fn func(*Context, *Value, []*Value) *Value) *Value {
 	// Store function in HandleStore and get int32 ID
 	fnID := ctx.handleStore.Store(fn)
 
-	return Value{
+	return &Value{
 		ctx: ctx,
 		ref: C.JS_NewCFunction2(
 			ctx.ref,
@@ -274,19 +274,19 @@ func (ctx *Context) Function(fn func(*Context, Value, []Value) Value) Value {
 // Deprecated: Use Context.Function + Context.Promise instead for better memory management and thread safety.
 // Example:
 //
-//	asyncFn := ctx.Function(func(ctx *quickjs.Context, this quickjs.Value, args []quickjs.Value) quickjs.Value {
-//	    return ctx.Promise(func(resolve, reject func(quickjs.Value)) {
+//	asyncFn := ctx.Function(func(ctx *quickjs.Context, this *quickjs.Value, args []*quickjs.Value) *quickjs.Value {
+//	    return ctx.Promise(func(resolve, reject func(*quickjs.Value)) {
 //	        // async work here
 //	        resolve(ctx.String("result"))
 //	    })
 //	})
-func (ctx *Context) AsyncFunction(asyncFn func(ctx *Context, this Value, promise Value, args []Value) Value) Value {
+func (ctx *Context) AsyncFunction(asyncFn func(ctx *Context, this *Value, promise *Value, args []*Value) *Value) *Value {
 	// New implementation using Function + Promise
-	return ctx.Function(func(ctx *Context, this Value, args []Value) Value {
-		return ctx.Promise(func(resolve, reject func(Value)) {
+	return ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
+		return ctx.Promise(func(resolve, reject func(*Value)) {
 			// Create a promise object that has resolve/reject methods
 			promiseObj := ctx.Object()
-			promiseObj.Set("resolve", ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+			promiseObj.Set("resolve", ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 				if len(args) > 0 {
 					resolve(args[0])
 				} else {
@@ -294,7 +294,7 @@ func (ctx *Context) AsyncFunction(asyncFn func(ctx *Context, this Value, promise
 				}
 				return ctx.Undefined()
 			}))
-			promiseObj.Set("reject", ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+			promiseObj.Set("reject", ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 				if len(args) > 0 {
 					reject(args[0])
 				} else {
@@ -347,16 +347,16 @@ func (ctx *Context) AtomIdx(idx uint32) Atom {
 
 // Invoke invokes a function with given this value and arguments.
 // Deprecated: Use Value.Execute() instead for better API consistency.
-func (ctx *Context) Invoke(fn Value, this Value, args ...Value) Value {
+func (ctx *Context) Invoke(fn *Value, this *Value, args ...*Value) *Value {
 	cargs := []C.JSValue{}
 	for _, x := range args {
 		cargs = append(cargs, x.ref)
 	}
-	var val Value
+	var val *Value
 	if len(cargs) == 0 {
-		val = Value{ctx: ctx, ref: C.JS_Call(ctx.ref, fn.ref, this.ref, 0, nil)}
+		val = &Value{ctx: ctx, ref: C.JS_Call(ctx.ref, fn.ref, this.ref, 0, nil)}
 	} else {
-		val = Value{ctx: ctx, ref: C.JS_Call(ctx.ref, fn.ref, this.ref, C.int(len(cargs)), &cargs[0])}
+		val = &Value{ctx: ctx, ref: C.JS_Call(ctx.ref, fn.ref, this.ref, C.int(len(cargs)), &cargs[0])}
 	}
 	return val
 }
@@ -417,8 +417,8 @@ func EvalLoadOnly(loadOnly bool) EvalOption {
 
 // Eval returns a js value with given code.
 // Need call Free() `quickjs.Value`'s returned by `Eval()` and `EvalFile()` and `EvalBytecode()`.
-// func (ctx *Context) Eval(code string) (Value, error) { return ctx.EvalFile(code, "code") }
-func (ctx *Context) Eval(code string, opts ...EvalOption) (Value, error) {
+// func (ctx *Context) Eval(code string) (*Value, error) { return ctx.EvalFile(code, "code") }
+func (ctx *Context) Eval(code string, opts ...EvalOption) (*Value, error) {
 	options := EvalOptions{
 		js_eval_type_global: true,
 		filename:            "<input>",
@@ -452,11 +452,11 @@ func (ctx *Context) Eval(code string, opts ...EvalOption) (Value, error) {
 		cFlag |= C.int(C.GetEvalTypeModule())
 	}
 
-	var val Value
+	var val *Value
 	if options.await {
-		val = Value{ctx: ctx, ref: C.js_std_await(ctx.ref, C.JS_Eval(ctx.ref, codePtr, C.size_t(len(code)), filenamePtr, cFlag))}
+		val = &Value{ctx: ctx, ref: C.js_std_await(ctx.ref, C.JS_Eval(ctx.ref, codePtr, C.size_t(len(code)), filenamePtr, cFlag))}
 	} else {
-		val = Value{ctx: ctx, ref: C.JS_Eval(ctx.ref, codePtr, C.size_t(len(code)), filenamePtr, cFlag)}
+		val = &Value{ctx: ctx, ref: C.JS_Eval(ctx.ref, codePtr, C.size_t(len(code)), filenamePtr, cFlag)}
 	}
 	if val.IsException() {
 		return val, ctx.Exception()
@@ -467,7 +467,7 @@ func (ctx *Context) Eval(code string, opts ...EvalOption) (Value, error) {
 
 // EvalFile returns a js value with given code and filename.
 // Need call Free() `quickjs.Value`'s returned by `Eval()` and `EvalFile()` and `EvalBytecode()`.
-func (ctx *Context) EvalFile(filePath string, opts ...EvalOption) (Value, error) {
+func (ctx *Context) EvalFile(filePath string, opts ...EvalOption) (*Value, error) {
 	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return ctx.Null(), err
@@ -477,7 +477,7 @@ func (ctx *Context) EvalFile(filePath string, opts ...EvalOption) (Value, error)
 }
 
 // LoadModule returns a js value with given code and module name.
-func (ctx *Context) LoadModule(code string, moduleName string, opts ...EvalOption) (Value, error) {
+func (ctx *Context) LoadModule(code string, moduleName string, opts ...EvalOption) (*Value, error) {
 	options := EvalOptions{
 		load_only: false,
 	}
@@ -502,7 +502,7 @@ func (ctx *Context) LoadModule(code string, moduleName string, opts ...EvalOptio
 }
 
 // LoadModuleFile returns a js value with given file path and module name.
-func (ctx *Context) LoadModuleFile(filePath string, moduleName string) (Value, error) {
+func (ctx *Context) LoadModuleFile(filePath string, moduleName string) (*Value, error) {
 	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return ctx.Null(), err
@@ -517,7 +517,7 @@ func (ctx *Context) CompileModule(filePath string, moduleName string, opts ...Ev
 }
 
 // LoadModuleByteCode returns a js value with given bytecode and module name.
-func (ctx *Context) LoadModuleBytecode(buf []byte, opts ...EvalOption) (Value, error) {
+func (ctx *Context) LoadModuleBytecode(buf []byte, opts ...EvalOption) (*Value, error) {
 	if len(buf) == 0 {
 		return ctx.Null(), fmt.Errorf("empty bytecode")
 	}
@@ -539,20 +539,20 @@ func (ctx *Context) LoadModuleBytecode(buf []byte, opts ...EvalOption) (Value, e
 		return ctx.Null(), ctx.Exception()
 	}
 
-	return Value{ctx: ctx, ref: cVal}, nil
+	return &Value{ctx: ctx, ref: cVal}, nil
 }
 
 // EvalBytecode returns a js value with given bytecode.
 // Need call Free() `quickjs.Value`'s returned by `Eval()` and `EvalFile()` and `EvalBytecode()`.
-func (ctx *Context) EvalBytecode(buf []byte) (Value, error) {
+func (ctx *Context) EvalBytecode(buf []byte) (*Value, error) {
 	cbuf := C.CBytes(buf)
-	obj := Value{ctx: ctx, ref: C.JS_ReadObject(ctx.ref, (*C.uint8_t)(cbuf), C.size_t(len(buf)), C.int(C.GetReadObjBytecode()))}
+	obj := &Value{ctx: ctx, ref: C.JS_ReadObject(ctx.ref, (*C.uint8_t)(cbuf), C.size_t(len(buf)), C.int(C.GetReadObjBytecode()))}
 	defer C.js_free(ctx.ref, unsafe.Pointer(cbuf))
 	if obj.IsException() {
 		return obj, ctx.Exception()
 	}
 
-	val := Value{ctx: ctx, ref: C.JS_EvalFunction(ctx.ref, obj.ref)}
+	val := &Value{ctx: ctx, ref: C.JS_EvalFunction(ctx.ref, obj.ref)}
 	if val.IsException() {
 		return val, ctx.Exception()
 	}
@@ -605,64 +605,64 @@ func (ctx *Context) CompileFile(filePath string, opts ...EvalOption) ([]byte, er
 }
 
 // Global returns a context's global object.
-func (ctx *Context) Globals() Value {
+func (ctx *Context) Globals() *Value {
 	if ctx.globals == nil {
 		ctx.globals = &Value{
 			ctx: ctx,
 			ref: C.JS_GetGlobalObject(ctx.ref),
 		}
 	}
-	return *ctx.globals
+	return ctx.globals
 }
 
 // Throw returns a context's exception value.
-func (ctx *Context) Throw(v Value) Value {
-	return Value{ctx: ctx, ref: C.JS_Throw(ctx.ref, v.ref)}
+func (ctx *Context) Throw(v *Value) *Value {
+	return &Value{ctx: ctx, ref: C.JS_Throw(ctx.ref, v.ref)}
 }
 
 // ThrowError returns a context's exception value with given error message.
-func (ctx *Context) ThrowError(err error) Value {
+func (ctx *Context) ThrowError(err error) *Value {
 	return ctx.Throw(ctx.Error(err))
 }
 
 // ThrowSyntaxError returns a context's exception value with given error message.
-func (ctx *Context) ThrowSyntaxError(format string, args ...interface{}) Value {
+func (ctx *Context) ThrowSyntaxError(format string, args ...interface{}) *Value {
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
-	return Value{ctx: ctx, ref: C.ThrowSyntaxError(ctx.ref, causePtr)}
+	return &Value{ctx: ctx, ref: C.ThrowSyntaxError(ctx.ref, causePtr)}
 }
 
 // ThrowTypeError returns a context's exception value with given error message.
-func (ctx *Context) ThrowTypeError(format string, args ...interface{}) Value {
+func (ctx *Context) ThrowTypeError(format string, args ...interface{}) *Value {
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
-	return Value{ctx: ctx, ref: C.ThrowTypeError(ctx.ref, causePtr)}
+	return &Value{ctx: ctx, ref: C.ThrowTypeError(ctx.ref, causePtr)}
 }
 
 // ThrowReferenceError returns a context's exception value with given error message.
-func (ctx *Context) ThrowReferenceError(format string, args ...interface{}) Value {
+func (ctx *Context) ThrowReferenceError(format string, args ...interface{}) *Value {
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
-	return Value{ctx: ctx, ref: C.ThrowReferenceError(ctx.ref, causePtr)}
+	return &Value{ctx: ctx, ref: C.ThrowReferenceError(ctx.ref, causePtr)}
 }
 
 // ThrowRangeError returns a context's exception value with given error message.
-func (ctx *Context) ThrowRangeError(format string, args ...interface{}) Value {
+func (ctx *Context) ThrowRangeError(format string, args ...interface{}) *Value {
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
-	return Value{ctx: ctx, ref: C.ThrowRangeError(ctx.ref, causePtr)}
+	return &Value{ctx: ctx, ref: C.ThrowRangeError(ctx.ref, causePtr)}
 }
 
 // ThrowInternalError returns a context's exception value with given error message.
-func (ctx *Context) ThrowInternalError(format string, args ...interface{}) Value {
+func (ctx *Context) ThrowInternalError(format string, args ...interface{}) *Value {
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
-	return Value{ctx: ctx, ref: C.ThrowInternalError(ctx.ref, causePtr)}
+	return &Value{ctx: ctx, ref: C.ThrowInternalError(ctx.ref, causePtr)}
 }
 
 // HasException checks if the context has an exception set.
@@ -673,7 +673,7 @@ func (ctx *Context) HasException() bool {
 
 // Exception returns a context's exception value.
 func (ctx *Context) Exception() error {
-	val := Value{ctx: ctx, ref: C.JS_GetException(ctx.ref)}
+	val := &Value{ctx: ctx, ref: C.JS_GetException(ctx.ref)}
 	defer val.Free()
 	return val.Error()
 }
@@ -684,8 +684,8 @@ func (ctx *Context) Loop() {
 }
 
 // Wait for a promise and execute pending jobs while waiting for it. Return the promise result or JS_EXCEPTION in case of promise rejection.
-func (ctx *Context) Await(v Value) (Value, error) {
-	val := Value{ctx: ctx, ref: C.js_std_await(ctx.ref, v.ref)}
+func (ctx *Context) Await(v *Value) (*Value, error) {
+	val := &Value{ctx: ctx, ref: C.js_std_await(ctx.ref, v.ref)}
 	if val.IsException() {
 		return val, ctx.Exception()
 	}
@@ -694,7 +694,7 @@ func (ctx *Context) Await(v Value) (Value, error) {
 
 // Promise creates a new Promise with executor function
 // Executor runs synchronously in current thread for thread safety
-func (ctx *Context) Promise(executor func(resolve, reject func(Value))) Value {
+func (ctx *Context) Promise(executor func(resolve, reject func(*Value))) *Value {
 	// Create Promise using JavaScript code to avoid complex C API reference management
 	promiseSetup, _ := ctx.Eval(`
         (() => {
@@ -716,11 +716,11 @@ func (ctx *Context) Promise(executor func(resolve, reject func(Value))) Value {
 	defer rejectFunc.Free()
 
 	// Create wrapper functions that call JavaScript resolve/reject
-	resolve := func(result Value) {
+	resolve := func(result *Value) {
 		resolveFunc.Execute(ctx.Undefined(), result)
 	}
 
-	reject := func(reason Value) {
+	reject := func(reason *Value) {
 		rejectFunc.Execute(ctx.Undefined(), reason)
 	}
 

--- a/error.go
+++ b/error.go
@@ -12,6 +12,6 @@ type Error struct {
 }
 
 // Error implements the error interface.
-func (err Error) Error() string {
+func (err *Error) Error() string {
 	return fmt.Sprintf("%s: %s", err.Name, err.Message)
 }

--- a/error_test.go
+++ b/error_test.go
@@ -144,7 +144,7 @@ func TestErrorSpecialCharacters(t *testing.T) {
 
 // TestErrorAsGoInterface tests Error implementing Go's error interface
 func TestErrorAsGoInterface(t *testing.T) {
-	quickjsErr := Error{
+	quickjsErr := &Error{
 		Name:    "TestError",
 		Message: "test error message",
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -10,7 +10,7 @@ import (
 // TestErrorBasics tests basic Error functionality and Error() method
 func TestErrorBasics(t *testing.T) {
 	// Test Error with all fields
-	err := Error{
+	err := &Error{
 		Name:       "TestError",
 		Message:    "test message",
 		Cause:      "test cause",
@@ -29,14 +29,14 @@ func TestErrorBasics(t *testing.T) {
 	require.EqualValues(t, `{"name":"TestError","message":"test message"}`, err.JSONString)
 
 	// Test empty Error
-	emptyErr := Error{}
+	emptyErr := &Error{}
 	require.EqualValues(t, ": ", emptyErr.Error())
 
 	// Test partial fields
-	nameOnlyErr := Error{Name: "OnlyName"}
+	nameOnlyErr := &Error{Name: "OnlyName"}
 	require.EqualValues(t, "OnlyName: ", nameOnlyErr.Error())
 
-	messageOnlyErr := Error{Message: "only message"}
+	messageOnlyErr := &Error{Message: "only message"}
 	require.EqualValues(t, ": only message", messageOnlyErr.Error())
 }
 
@@ -58,7 +58,7 @@ func TestErrorStandardTypes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := Error{
+			err := &Error{
 				Name:    tc.errorName,
 				Message: tc.message,
 			}
@@ -121,7 +121,7 @@ func TestErrorSpecialCharacters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := Error{
+			err := &Error{
 				Name:    tc.errorName,
 				Message: tc.message,
 			}
@@ -133,7 +133,7 @@ func TestErrorSpecialCharacters(t *testing.T) {
 	longName := strings.Repeat("A", 100)
 	longMessage := strings.Repeat("a", 500)
 
-	longErr := Error{
+	longErr := &Error{
 		Name:    longName,
 		Message: longMessage,
 	}
@@ -162,20 +162,21 @@ func TestErrorAsGoInterface(t *testing.T) {
 	require.Error(t, err)
 	require.EqualValues(t, "TestError: test error message", err.Error())
 
-	// Test struct equality
-	err1 := Error{Name: "TestError", Message: "test message"}
-	err2 := Error{Name: "TestError", Message: "test message"}
-	err3 := Error{Name: "DifferentError", Message: "test message"}
+	// Test struct equality (comparing values, not pointers)
+	err1 := &Error{Name: "TestError", Message: "test message"}
+	err2 := &Error{Name: "TestError", Message: "test message"}
+	err3 := &Error{Name: "DifferentError", Message: "test message"}
 
-	require.Equal(t, err1, err2)
-	require.NotEqual(t, err1, err3)
+	// Compare values, not pointer addresses
+	require.Equal(t, *err1, *err2)
+	require.NotEqual(t, *err1, *err3)
 	require.EqualValues(t, err1.Error(), err2.Error())
 	require.NotEqual(t, err1.Error(), err3.Error())
 }
 
 // TestErrorFieldManipulation tests field access and modification
 func TestErrorFieldManipulation(t *testing.T) {
-	err := Error{
+	err := &Error{
 		Name:    "InitialError",
 		Message: "initial message",
 	}
@@ -199,7 +200,7 @@ func TestErrorFieldManipulation(t *testing.T) {
 	require.EqualValues(t, `{"modified": true}`, err.JSONString)
 
 	// Test zero value behavior
-	var zeroErr Error
+	var zeroErr *Error = &Error{}
 	require.EqualValues(t, "", zeroErr.Name)
 	require.EqualValues(t, "", zeroErr.Message)
 	require.EqualValues(t, "", zeroErr.Cause)

--- a/marshal.go
+++ b/marshal.go
@@ -11,12 +11,12 @@ import (
 
 // Marshaler is the interface implemented by types that can marshal themselves into a JavaScript value.
 type Marshaler interface {
-	MarshalJS(ctx *Context) (Value, error)
+	MarshalJS(ctx *Context) (*Value, error)
 }
 
 // Unmarshaler is the interface implemented by types that can unmarshal a JavaScript value into themselves.
 type Unmarshaler interface {
-	UnmarshalJS(ctx *Context, val Value) error
+	UnmarshalJS(ctx *Context, val *Value) error
 }
 
 // FieldTagInfo contains parsed field tag information
@@ -137,7 +137,7 @@ func isEmptyValue(v reflect.Value) bool {
 // The "js" and "json" tags are supported. Fields with tag "-" are ignored.
 //
 // Types implementing the Marshaler interface are marshaled using their MarshalJS method.
-func (ctx *Context) Marshal(v interface{}) (Value, error) {
+func (ctx *Context) Marshal(v interface{}) (*Value, error) {
 	if v == nil {
 		return ctx.Null(), nil
 	}
@@ -174,7 +174,7 @@ func (ctx *Context) Marshal(v interface{}) (Value, error) {
 //   - map[string]interface{} for JavaScript Object
 //
 // Types implementing the Unmarshaler interface are unmarshaled using their UnmarshalJS method.
-func (ctx *Context) Unmarshal(jsVal Value, v interface{}) error {
+func (ctx *Context) Unmarshal(jsVal *Value, v interface{}) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {
 		return fmt.Errorf("unmarshal target must be a non-nil pointer")
@@ -183,7 +183,7 @@ func (ctx *Context) Unmarshal(jsVal Value, v interface{}) error {
 }
 
 // marshal recursively marshals a Go value to JavaScript
-func (ctx *Context) marshal(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshal(rv reflect.Value) (*Value, error) {
 	// Handle interface{} by getting the concrete value
 	if rv.Kind() == reflect.Interface && !rv.IsNil() {
 		rv = rv.Elem()
@@ -244,7 +244,7 @@ func (ctx *Context) marshal(rv reflect.Value) (Value, error) {
 }
 
 // marshalSlice marshals Go slice to JavaScript Array or TypedArray
-func (ctx *Context) marshalSlice(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalSlice(rv reflect.Value) (*Value, error) {
 	elemKind := rv.Type().Elem().Kind()
 
 	switch elemKind {
@@ -296,7 +296,7 @@ func (ctx *Context) marshalSlice(rv reflect.Value) (Value, error) {
 }
 
 // marshalInt8Array converts []int8 to Int8Array
-func (ctx *Context) marshalInt8Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalInt8Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]int8)
 	bytes := make([]byte, len(slice))
 	for i, v := range slice {
@@ -314,7 +314,7 @@ func (ctx *Context) marshalInt8Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalInt16Array converts []int16 to Int16Array
-func (ctx *Context) marshalInt16Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalInt16Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]int16)
 	bytes := int16SliceToBytes(slice)
 
@@ -329,7 +329,7 @@ func (ctx *Context) marshalInt16Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalUint16Array converts []uint16 to Uint16Array
-func (ctx *Context) marshalUint16Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalUint16Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]uint16)
 	bytes := uint16SliceToBytes(slice)
 
@@ -344,7 +344,7 @@ func (ctx *Context) marshalUint16Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalInt32Array converts []int32 to Int32Array
-func (ctx *Context) marshalInt32Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalInt32Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]int32)
 	bytes := int32SliceToBytes(slice)
 
@@ -359,7 +359,7 @@ func (ctx *Context) marshalInt32Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalUint32Array converts []uint32 to Uint32Array
-func (ctx *Context) marshalUint32Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalUint32Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]uint32)
 	bytes := uint32SliceToBytes(slice)
 
@@ -374,7 +374,7 @@ func (ctx *Context) marshalUint32Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalFloat32Array converts []float32 to Float32Array
-func (ctx *Context) marshalFloat32Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalFloat32Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]float32)
 	bytes := float32SliceToBytes(slice)
 
@@ -389,7 +389,7 @@ func (ctx *Context) marshalFloat32Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalFloat64Array converts []float64 to Float64Array
-func (ctx *Context) marshalFloat64Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalFloat64Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]float64)
 	bytes := float64SliceToBytes(slice)
 
@@ -404,7 +404,7 @@ func (ctx *Context) marshalFloat64Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalBigInt64Array converts []int64 to BigInt64Array
-func (ctx *Context) marshalBigInt64Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalBigInt64Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]int64)
 	bytes := int64SliceToBytes(slice)
 
@@ -419,7 +419,7 @@ func (ctx *Context) marshalBigInt64Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalBigUint64Array converts []uint64 to BigUint64Array
-func (ctx *Context) marshalBigUint64Array(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalBigUint64Array(rv reflect.Value) (*Value, error) {
 	slice := rv.Interface().([]uint64)
 	bytes := uint64SliceToBytes(slice)
 
@@ -434,7 +434,7 @@ func (ctx *Context) marshalBigUint64Array(rv reflect.Value) (Value, error) {
 }
 
 // marshalGenericArray marshals Go slice to JavaScript Array (fallback)
-func (ctx *Context) marshalGenericArray(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalGenericArray(rv reflect.Value) (*Value, error) {
 	globals := ctx.Globals()
 	arrayClass := globals.Get("Array")
 	defer arrayClass.Free()
@@ -559,7 +559,7 @@ func uint64SliceToBytes(slice []uint64) []byte {
 }
 
 // marshalArray marshals Go array to JavaScript Array
-func (ctx *Context) marshalArray(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalArray(rv reflect.Value) (*Value, error) {
 	globals := ctx.Globals()
 	arrayClass := globals.Get("Array")
 	defer arrayClass.Free()
@@ -578,7 +578,7 @@ func (ctx *Context) marshalArray(rv reflect.Value) (Value, error) {
 }
 
 // marshalMap marshals Go map to JavaScript Object
-func (ctx *Context) marshalMap(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalMap(rv reflect.Value) (*Value, error) {
 	obj := ctx.Object()
 	for _, key := range rv.MapKeys() {
 		keyStr := fmt.Sprintf("%v", key.Interface())
@@ -594,7 +594,7 @@ func (ctx *Context) marshalMap(rv reflect.Value) (Value, error) {
 }
 
 // marshalStruct marshals Go struct to JavaScript Object
-func (ctx *Context) marshalStruct(rv reflect.Value) (Value, error) {
+func (ctx *Context) marshalStruct(rv reflect.Value) (*Value, error) {
 	rt := rv.Type()
 	obj := ctx.Object()
 
@@ -631,7 +631,7 @@ func (ctx *Context) marshalStruct(rv reflect.Value) (Value, error) {
 }
 
 // unmarshal recursively unmarshals a JavaScript value to Go
-func (ctx *Context) unmarshal(jsVal Value, rv reflect.Value) error {
+func (ctx *Context) unmarshal(jsVal *Value, rv reflect.Value) error {
 	// Check if type implements Unmarshaler interface
 	if rv.CanAddr() {
 		if unmarshaler, ok := rv.Addr().Interface().(Unmarshaler); ok {
@@ -751,7 +751,7 @@ func (ctx *Context) unmarshal(jsVal Value, rv reflect.Value) error {
 }
 
 // unmarshalSlice unmarshals JavaScript Array/TypedArray to Go slice
-func (ctx *Context) unmarshalSlice(jsVal Value, rv reflect.Value) error {
+func (ctx *Context) unmarshalSlice(jsVal *Value, rv reflect.Value) error {
 	elemKind := rv.Type().Elem().Kind()
 
 	// Check for corresponding TypedArray types first
@@ -889,7 +889,7 @@ func (ctx *Context) unmarshalSlice(jsVal Value, rv reflect.Value) error {
 }
 
 // unmarshalArray unmarshals JavaScript Array to Go array
-func (ctx *Context) unmarshalArray(jsVal Value, rv reflect.Value) error {
+func (ctx *Context) unmarshalArray(jsVal *Value, rv reflect.Value) error {
 	if !jsVal.IsArray() {
 		return fmt.Errorf("expected array, got JavaScript %s", jsVal.String())
 	}
@@ -916,7 +916,7 @@ func (ctx *Context) unmarshalArray(jsVal Value, rv reflect.Value) error {
 }
 
 // unmarshalMap unmarshals JavaScript Object to Go map
-func (ctx *Context) unmarshalMap(jsVal Value, rv reflect.Value) error {
+func (ctx *Context) unmarshalMap(jsVal *Value, rv reflect.Value) error {
 	if !jsVal.IsObject() {
 		return fmt.Errorf("expected object, got JavaScript %s", jsVal.String())
 	}
@@ -965,7 +965,7 @@ func (ctx *Context) unmarshalMap(jsVal Value, rv reflect.Value) error {
 }
 
 // unmarshalStruct unmarshals JavaScript Object to Go struct
-func (ctx *Context) unmarshalStruct(jsVal Value, rv reflect.Value) error {
+func (ctx *Context) unmarshalStruct(jsVal *Value, rv reflect.Value) error {
 	if !jsVal.IsObject() {
 		return fmt.Errorf("expected object, got JavaScript %s", jsVal.String())
 	}
@@ -999,7 +999,7 @@ func (ctx *Context) unmarshalStruct(jsVal Value, rv reflect.Value) error {
 }
 
 // unmarshalInterface unmarshals JavaScript value to interface{}
-func (ctx *Context) unmarshalInterface(jsVal Value) (interface{}, error) {
+func (ctx *Context) unmarshalInterface(jsVal *Value) (interface{}, error) {
 	if jsVal.IsFunction() || jsVal.IsSymbol() || jsVal.IsException() || jsVal.IsUninitialized() || jsVal.IsPromise() || jsVal.IsConstructor() {
 		return nil, fmt.Errorf("unsupported JavaScript type")
 	} else if jsVal.IsNull() || jsVal.IsUndefined() {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -17,7 +17,7 @@ type CustomMarshalType struct {
 	Value string
 }
 
-func (c CustomMarshalType) MarshalJS(ctx *Context) (Value, error) {
+func (c CustomMarshalType) MarshalJS(ctx *Context) (*Value, error) {
 	return ctx.String("custom:" + c.Value), nil
 }
 
@@ -25,7 +25,7 @@ type CustomUnmarshalType struct {
 	Value string
 }
 
-func (c *CustomUnmarshalType) UnmarshalJS(ctx *Context, val Value) error {
+func (c *CustomUnmarshalType) UnmarshalJS(ctx *Context, val *Value) error {
 	if val.IsString() {
 		str := val.ToString()
 		if len(str) > 7 && str[:7] == "custom:" {
@@ -39,13 +39,13 @@ func (c *CustomUnmarshalType) UnmarshalJS(ctx *Context, val Value) error {
 
 type ErrorMarshalType struct{}
 
-func (e ErrorMarshalType) MarshalJS(ctx *Context) (Value, error) {
+func (e ErrorMarshalType) MarshalJS(ctx *Context) (*Value, error) {
 	return ctx.Null(), errors.New("marshal error")
 }
 
 type ErrorUnmarshalType struct{}
 
-func (e *ErrorUnmarshalType) UnmarshalJS(ctx *Context, val Value) error {
+func (e *ErrorUnmarshalType) UnmarshalJS(ctx *Context, val *Value) error {
 	return errors.New("unmarshal error")
 }
 
@@ -105,11 +105,11 @@ type TimeWrapper struct {
 	time.Time
 }
 
-func (t TimeWrapper) MarshalJS(ctx *Context) (Value, error) {
+func (t TimeWrapper) MarshalJS(ctx *Context) (*Value, error) {
 	return ctx.String(t.Format(time.RFC3339)), nil
 }
 
-func (t *TimeWrapper) UnmarshalJS(ctx *Context, val Value) error {
+func (t *TimeWrapper) UnmarshalJS(ctx *Context, val *Value) error {
 	if val.IsString() {
 		parsed, err := time.Parse(time.RFC3339, val.ToString())
 		if err != nil {
@@ -537,7 +537,7 @@ func TestTypedArrays(t *testing.T) {
 	defer ctx.Close()
 
 	// Helper function for TypedArray round-trip tests
-	testTypedArrayRoundTrip := func(t *testing.T, name string, data interface{}, checkFunc func(Value) bool) {
+	testTypedArrayRoundTrip := func(t *testing.T, name string, data interface{}, checkFunc func(*Value) bool) {
 		t.Run(name, func(t *testing.T) {
 			jsVal, err := ctx.Marshal(data)
 			require.NoError(t, err)
@@ -572,15 +572,15 @@ func TestTypedArrays(t *testing.T) {
 	}
 
 	// Test all TypedArray types
-	testTypedArrayRoundTrip(t, "Int8Array", []int8{-128, -1, 0, 1, 127}, func(v Value) bool { return v.IsInt8Array() })
-	testTypedArrayRoundTrip(t, "Int16Array", []int16{-32768, -1, 0, 1, 32767}, func(v Value) bool { return v.IsInt16Array() })
-	testTypedArrayRoundTrip(t, "Uint16Array", []uint16{0, 1, 32768, 65535}, func(v Value) bool { return v.IsUint16Array() })
-	testTypedArrayRoundTrip(t, "Int32Array", []int32{-2147483648, -1, 0, 1, 2147483647}, func(v Value) bool { return v.IsInt32Array() })
-	testTypedArrayRoundTrip(t, "Uint32Array", []uint32{0, 1, 2147483648, 4294967295}, func(v Value) bool { return v.IsUint32Array() })
-	testTypedArrayRoundTrip(t, "Float32Array", []float32{-3.14, 0.0, 2.718, float32(1 << 20)}, func(v Value) bool { return v.IsFloat32Array() })
-	testTypedArrayRoundTrip(t, "Float64Array", []float64{-3.141592653589793, 0.0, 2.718281828459045, 1e10}, func(v Value) bool { return v.IsFloat64Array() })
-	testTypedArrayRoundTrip(t, "BigInt64Array", []int64{-9223372036854775808, -1, 0, 1, 9223372036854775807}, func(v Value) bool { return v.IsBigInt64Array() })
-	testTypedArrayRoundTrip(t, "BigUint64Array", []uint64{0, 1, 9223372036854775808, 18446744073709551615}, func(v Value) bool { return v.IsBigUint64Array() })
+	testTypedArrayRoundTrip(t, "Int8Array", []int8{-128, -1, 0, 1, 127}, func(v *Value) bool { return v.IsInt8Array() })
+	testTypedArrayRoundTrip(t, "Int16Array", []int16{-32768, -1, 0, 1, 32767}, func(v *Value) bool { return v.IsInt16Array() })
+	testTypedArrayRoundTrip(t, "Uint16Array", []uint16{0, 1, 32768, 65535}, func(v *Value) bool { return v.IsUint16Array() })
+	testTypedArrayRoundTrip(t, "Int32Array", []int32{-2147483648, -1, 0, 1, 2147483647}, func(v *Value) bool { return v.IsInt32Array() })
+	testTypedArrayRoundTrip(t, "Uint32Array", []uint32{0, 1, 2147483648, 4294967295}, func(v *Value) bool { return v.IsUint32Array() })
+	testTypedArrayRoundTrip(t, "Float32Array", []float32{-3.14, 0.0, 2.718, float32(1 << 20)}, func(v *Value) bool { return v.IsFloat32Array() })
+	testTypedArrayRoundTrip(t, "Float64Array", []float64{-3.141592653589793, 0.0, 2.718281828459045, 1e10}, func(v *Value) bool { return v.IsFloat64Array() })
+	testTypedArrayRoundTrip(t, "BigInt64Array", []int64{-9223372036854775808, -1, 0, 1, 9223372036854775807}, func(v *Value) bool { return v.IsBigInt64Array() })
+	testTypedArrayRoundTrip(t, "BigUint64Array", []uint64{0, 1, 9223372036854775808, 18446744073709551615}, func(v *Value) bool { return v.IsBigUint64Array() })
 
 	// Test []byte -> ArrayBuffer (special case)
 	t.Run("ByteSliceToArrayBuffer", func(t *testing.T) {
@@ -603,17 +603,17 @@ func TestTypedArrays(t *testing.T) {
 		emptyTests := []struct {
 			name  string
 			data  interface{}
-			check func(Value) bool
+			check func(*Value) bool
 		}{
-			{"EmptyInt8Array", []int8{}, func(v Value) bool { return v.IsInt8Array() }},
-			{"EmptyInt16Array", []int16{}, func(v Value) bool { return v.IsInt16Array() }},
-			{"EmptyUint16Array", []uint16{}, func(v Value) bool { return v.IsUint16Array() }},
-			{"EmptyInt32Array", []int32{}, func(v Value) bool { return v.IsInt32Array() }},
-			{"EmptyUint32Array", []uint32{}, func(v Value) bool { return v.IsUint32Array() }},
-			{"EmptyFloat32Array", []float32{}, func(v Value) bool { return v.IsFloat32Array() }},
-			{"EmptyFloat64Array", []float64{}, func(v Value) bool { return v.IsFloat64Array() }},
-			{"EmptyBigInt64Array", []int64{}, func(v Value) bool { return v.IsBigInt64Array() }},
-			{"EmptyBigUint64Array", []uint64{}, func(v Value) bool { return v.IsBigUint64Array() }},
+			{"EmptyInt8Array", []int8{}, func(v *Value) bool { return v.IsInt8Array() }},
+			{"EmptyInt16Array", []int16{}, func(v *Value) bool { return v.IsInt16Array() }},
+			{"EmptyUint16Array", []uint16{}, func(v *Value) bool { return v.IsUint16Array() }},
+			{"EmptyInt32Array", []int32{}, func(v *Value) bool { return v.IsInt32Array() }},
+			{"EmptyUint32Array", []uint32{}, func(v *Value) bool { return v.IsUint32Array() }},
+			{"EmptyFloat32Array", []float32{}, func(v *Value) bool { return v.IsFloat32Array() }},
+			{"EmptyFloat64Array", []float64{}, func(v *Value) bool { return v.IsFloat64Array() }},
+			{"EmptyBigInt64Array", []int64{}, func(v *Value) bool { return v.IsBigInt64Array() }},
+			{"EmptyBigUint64Array", []uint64{}, func(v *Value) bool { return v.IsBigUint64Array() }},
 		}
 
 		for _, tt := range emptyTests {
@@ -672,7 +672,7 @@ func TestTypedArrayErrors(t *testing.T) {
 	defer ctx.Close()
 
 	// Helper function to create fake TypedArray objects
-	createFakeTypedArray := func(typeName string) Value {
+	createFakeTypedArray := func(typeName string) *Value {
 		jsCode := fmt.Sprintf(`
             var corrupted = Object.create(%s.prototype);
             Object.defineProperty(corrupted, 'constructor', {
@@ -1003,7 +1003,7 @@ func TestUnmarshalInterface(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var jsVal Value
+			var jsVal *Value
 			var err error
 
 			if tt.jsCode == "undefined" {

--- a/module.go
+++ b/module.go
@@ -18,7 +18,7 @@ import "C"
 // ModuleExportEntry represents a single module export
 type ModuleExportEntry struct {
 	Name  string // Export name ("default" for default export)
-	Value Value  // Export value
+	Value *Value // Export value - changed to pointer type
 }
 
 // ModuleBuilder provides a fluent API for building JavaScript modules
@@ -44,10 +44,10 @@ func NewModuleBuilder(name string) *ModuleBuilder {
 // Export adds an export to the module
 // This is the core method that handles all types of exports including default
 // For default export, use name="default"
-func (mb *ModuleBuilder) Export(name string, value Value) *ModuleBuilder {
+func (mb *ModuleBuilder) Export(name string, value *Value) *ModuleBuilder {
 	mb.exports = append(mb.exports, ModuleExportEntry{
 		Name:  name,
-		Value: value,
+		Value: value, // Now expects *Value
 	})
 	return mb
 }

--- a/module_test.go
+++ b/module_test.go
@@ -18,7 +18,7 @@ func TestModuleBuilder_Basic(t *testing.T) {
 	defer ctx.Close()
 
 	t.Run("ModuleWithExports", func(t *testing.T) {
-		addFunc := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		addFunc := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			if len(args) >= 2 {
 				return ctx.Float64(args[0].Float64() + args[1].Float64())
 			}
@@ -78,7 +78,7 @@ func TestModuleBuilder_Import(t *testing.T) {
 	defer ctx.Close()
 
 	t.Run("NamedImports", func(t *testing.T) {
-		greetFunc := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		greetFunc := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			name := "World"
 			if len(args) > 0 {
 				name = args[0].String()
@@ -106,7 +106,7 @@ func TestModuleBuilder_Import(t *testing.T) {
 	})
 
 	t.Run("FunctionImports", func(t *testing.T) {
-		calculateFunc := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		calculateFunc := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			if len(args) >= 2 {
 				a, b := args[0].Float64(), args[1].Float64()
 				return ctx.Float64(a * b)
@@ -209,7 +209,7 @@ func TestModuleBuilder_Integration(t *testing.T) {
 
 	t.Run("MultipleModules", func(t *testing.T) {
 		// Create math module
-		addFunc := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		addFunc := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			if len(args) >= 2 {
 				return ctx.Float64(args[0].Float64() + args[1].Float64())
 			}

--- a/quickjs_test.go
+++ b/quickjs_test.go
@@ -46,11 +46,11 @@ func Example() {
 	test := ctx.Object()
 	defer test.Free()
 	// bind properties to the object
-	test.Set("A", test.Context().String("String A"))
+	test.Set("A", ctx.String("String A"))
 	test.Set("B", ctx.Int32(0))
 	test.Set("C", ctx.Bool(false))
-	// bind go function to js object
-	test.Set("hello", ctx.Function(func(ctx *quickjs.Context, this quickjs.Value, args []quickjs.Value) quickjs.Value {
+	// bind go function to js object - UPDATED: function signature now uses pointers
+	test.Set("hello", ctx.Function(func(ctx *quickjs.Context, this *quickjs.Value, args []*quickjs.Value) *quickjs.Value {
 		return ctx.String("Hello " + args[0].String())
 	}))
 
@@ -67,9 +67,9 @@ func Example() {
 	defer go_ret.Free()
 	fmt.Println(go_ret.String())
 
-	// bind go function to Javascript async function using Function + Promise
-	ctx.Globals().Set("testAsync", ctx.Function(func(ctx *quickjs.Context, this quickjs.Value, args []quickjs.Value) quickjs.Value {
-		return ctx.Promise(func(resolve, reject func(quickjs.Value)) {
+	// bind go function to Javascript async function using Function + Promise - UPDATED: function signature now uses pointers
+	ctx.Globals().Set("testAsync", ctx.Function(func(ctx *quickjs.Context, this *quickjs.Value, args []*quickjs.Value) *quickjs.Value {
+		return ctx.Promise(func(resolve, reject func(*quickjs.Value)) {
 			resolve(ctx.String("Hello Async Function!"))
 		})
 	}))

--- a/value.go
+++ b/value.go
@@ -21,7 +21,7 @@ type Value struct {
 }
 
 // Free the value.
-func (v Value) Free() {
+func (v *Value) Free() {
 	if v.ctx == nil || C.JS_IsUndefined_Wrapper(v.ref) == 1 {
 		return // No context or undefined value, nothing to free
 	}
@@ -29,42 +29,42 @@ func (v Value) Free() {
 }
 
 // Context returns the context of the value.
-func (v Value) Context() *Context {
+func (v *Value) Context() *Context {
 	return v.ctx
 }
 
 // Deprecated: Use ToBool instead.
-func (v Value) Bool() bool {
+func (v *Value) Bool() bool {
 	return v.ToBool()
 }
 
 // ToBool returns the boolean value of the value.
-func (v Value) ToBool() bool {
+func (v *Value) ToBool() bool {
 	return C.JS_ToBool(v.ctx.ref, v.ref) == 1
 }
 
 // String returns the string representation of the value.
 // This method implements the fmt.Stringer interface.
-func (v Value) String() string {
+func (v *Value) String() string {
 	return v.ToString()
 }
 
 // ToString returns the string representation of the value.
-func (v Value) ToString() string {
+func (v *Value) ToString() string {
 	ptr := C.JS_ToCString(v.ctx.ref, v.ref)
 	defer C.JS_FreeCString(v.ctx.ref, ptr)
 	return C.GoString(ptr)
 }
 
 // JSONStringify returns the JSON string representation of the value.
-func (v Value) JSONStringify() string {
+func (v *Value) JSONStringify() string {
 	ref := C.JS_JSONStringify(v.ctx.ref, v.ref, C.JS_NewNull(), C.JS_NewNull())
 	ptr := C.JS_ToCString(v.ctx.ref, ref)
 	defer C.JS_FreeCString(v.ctx.ref, ptr)
 	return C.GoString(ptr)
 }
 
-func (v Value) ToByteArray(size uint) ([]byte, error) {
+func (v *Value) ToByteArray(size uint) ([]byte, error) {
 	if v.ByteLen() < int64(size) {
 		return nil, errors.New("exceeds the maximum length of the current binary array")
 	}
@@ -78,66 +78,61 @@ func (v Value) ToByteArray(size uint) ([]byte, error) {
 	return C.GoBytes(unsafe.Pointer(outBuf), C.int(size)), nil
 }
 
-// IsByteArray returns true if the value is array buffer
-func (v Value) IsByteArray() bool {
-	return v.IsObject() && v.GlobalInstanceof("ArrayBuffer") || v.String() == "[object ArrayBuffer]"
-}
-
 // Deprecated: Use ToInt64 instead.
-func (v Value) Int64() int64 {
+func (v *Value) Int64() int64 {
 	return v.ToInt64()
 }
 
 // ToInt64 returns the int64 value of the value.
-func (v Value) ToInt64() int64 {
+func (v *Value) ToInt64() int64 {
 	val := C.int64_t(0)
 	C.JS_ToInt64(v.ctx.ref, &val, v.ref)
 	return int64(val)
 }
 
 // Deprecated: Use ToInt32 instead.
-func (v Value) Int32() int32 {
+func (v *Value) Int32() int32 {
 	return v.ToInt32()
 }
 
 // ToInt32 returns the int32 value of the value.
-func (v Value) ToInt32() int32 {
+func (v *Value) ToInt32() int32 {
 	val := C.int32_t(0)
 	C.JS_ToInt32(v.ctx.ref, &val, v.ref)
 	return int32(val)
 }
 
 // Deprecated: Use ToUint32 instead.
-func (v Value) Uint32() uint32 {
+func (v *Value) Uint32() uint32 {
 	return v.ToUint32()
 }
 
 // ToUint32 returns the uint32 value of the value.
-func (v Value) ToUint32() uint32 {
+func (v *Value) ToUint32() uint32 {
 	val := C.uint32_t(0)
 	C.JS_ToUint32(v.ctx.ref, &val, v.ref)
 	return uint32(val)
 }
 
 // Deprecated: Use ToFloat64 instead.
-func (v Value) Float64() float64 {
+func (v *Value) Float64() float64 {
 	return v.ToFloat64()
 }
 
 // ToFloat64 returns the float64 value of the value.
-func (v Value) ToFloat64() float64 {
+func (v *Value) ToFloat64() float64 {
 	val := C.double(0)
 	C.JS_ToFloat64(v.ctx.ref, &val, v.ref)
 	return float64(val)
 }
 
 // Deprecated: Use ToBigInt instead.
-func (v Value) BigInt() *big.Int {
+func (v *Value) BigInt() *big.Int {
 	return v.ToBigInt()
 }
 
 // ToBigInt returns the big.Int value of the value.
-func (v Value) ToBigInt() *big.Int {
+func (v *Value) ToBigInt() *big.Int {
 	if !v.IsBigInt() {
 		return nil
 	}
@@ -146,41 +141,45 @@ func (v Value) ToBigInt() *big.Int {
 }
 
 // Len returns the length of the array.
-func (v Value) Len() int64 {
-	return v.Get("length").Int64()
+func (v *Value) Len() int64 {
+	length := v.Get("length")
+	defer length.Free()
+	return length.Int64()
 }
 
 // ByteLen returns the length of the ArrayBuffer.
-func (v Value) ByteLen() int64 {
-	return v.Get("byteLength").Int64()
+func (v *Value) ByteLen() int64 {
+	byteLength := v.Get("byteLength")
+	defer byteLength.Free()
+	return byteLength.Int64()
 }
 
 // Set sets the value of the property with the given name.
-func (v Value) Set(name string, val Value) {
+func (v *Value) Set(name string, val *Value) {
 	namePtr := C.CString(name)
 	defer C.free(unsafe.Pointer(namePtr))
 	C.JS_SetPropertyStr(v.ctx.ref, v.ref, namePtr, val.ref)
 }
 
 // SetIdx sets the value of the property with the given index.
-func (v Value) SetIdx(idx int64, val Value) {
+func (v *Value) SetIdx(idx int64, val *Value) {
 	C.JS_SetPropertyUint32(v.ctx.ref, v.ref, C.uint32_t(idx), val.ref)
 }
 
 // Get returns the value of the property with the given name.
-func (v Value) Get(name string) Value {
+func (v *Value) Get(name string) *Value {
 	namePtr := C.CString(name)
 	defer C.free(unsafe.Pointer(namePtr))
-	return Value{ctx: v.ctx, ref: C.JS_GetPropertyStr(v.ctx.ref, v.ref, namePtr)}
+	return &Value{ctx: v.ctx, ref: C.JS_GetPropertyStr(v.ctx.ref, v.ref, namePtr)}
 }
 
 // GetIdx returns the value of the property with the given index.
-func (v Value) GetIdx(idx int64) Value {
-	return Value{ctx: v.ctx, ref: C.JS_GetPropertyUint32(v.ctx.ref, v.ref, C.uint32_t(idx))}
+func (v *Value) GetIdx(idx int64) *Value {
+	return &Value{ctx: v.ctx, ref: C.JS_GetPropertyUint32(v.ctx.ref, v.ref, C.uint32_t(idx))}
 }
 
 // Call calls the function with the given arguments.
-func (v Value) Call(fname string, args ...Value) Value {
+func (v *Value) Call(fname string, args ...*Value) *Value {
 	fn := v.Get(fname) // get the function by name
 	defer fn.Free()
 
@@ -188,34 +187,34 @@ func (v Value) Call(fname string, args ...Value) Value {
 	for _, x := range args {
 		cargs = append(cargs, x.ref)
 	}
-	var val Value
+	var val *Value
 	if len(cargs) == 0 {
-		val = Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, fn.ref, v.ref, C.int(0), nil)}
+		val = &Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, fn.ref, v.ref, C.int(0), nil)}
 	} else {
-		val = Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, fn.ref, v.ref, C.int(len(cargs)), &cargs[0])}
+		val = &Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, fn.ref, v.ref, C.int(len(cargs)), &cargs[0])}
 	}
 
 	return val
 }
 
 // Execute the function with the given arguments.
-func (v Value) Execute(this Value, args ...Value) Value {
+func (v *Value) Execute(this *Value, args ...*Value) *Value {
 	cargs := []C.JSValue{}
 	for _, x := range args {
 		cargs = append(cargs, x.ref)
 	}
-	var val Value
+	var val *Value
 	if len(cargs) == 0 {
-		val = Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, v.ref, this.ref, C.int(0), nil)}
+		val = &Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, v.ref, this.ref, C.int(0), nil)}
 	} else {
-		val = Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, v.ref, this.ref, C.int(len(cargs)), &cargs[0])}
+		val = &Value{ctx: v.ctx, ref: C.JS_Call(v.ctx.ref, v.ref, this.ref, C.int(len(cargs)), &cargs[0])}
 	}
 
 	return val
 }
 
 // New calls the constructor with the given arguments.
-func (v Value) New(args ...Value) Value {
+func (v *Value) New(args ...*Value) *Value {
 	return v.CallConstructor(args...)
 }
 
@@ -231,28 +230,28 @@ func (v Value) New(args ...Value) Value {
 //
 // This replaces the previous NewInstance method and provides automatic property binding
 // and simplified constructor semantics where constructors work with pre-created instances.
-func (v Value) CallConstructor(args ...Value) Value {
+func (v *Value) CallConstructor(args ...*Value) *Value {
 	cargs := []C.JSValue{}
 	for _, x := range args {
 		cargs = append(cargs, x.ref)
 	}
-	var val Value
+	var val *Value
 	if len(cargs) == 0 {
-		val = Value{ctx: v.ctx, ref: C.JS_CallConstructor(v.ctx.ref, v.ref, C.int(0), nil)}
+		val = &Value{ctx: v.ctx, ref: C.JS_CallConstructor(v.ctx.ref, v.ref, C.int(0), nil)}
 	} else {
-		val = Value{ctx: v.ctx, ref: C.JS_CallConstructor(v.ctx.ref, v.ref, C.int(len(cargs)), &cargs[0])}
+		val = &Value{ctx: v.ctx, ref: C.JS_CallConstructor(v.ctx.ref, v.ref, C.int(len(cargs)), &cargs[0])}
 	}
 
 	return val
 }
 
 // Deprecated: Use ToError() instead.
-func (v Value) Error() error {
+func (v *Value) Error() error {
 	return v.ToError()
 }
 
 // ToError returns the error value of the value.
-func (v Value) ToError() error {
+func (v *Value) ToError() error {
 	if !v.IsError() {
 		return nil
 	}
@@ -292,7 +291,7 @@ func (v Value) ToError() error {
 }
 
 // propertyEnum is a wrapper around JSValue.
-func (v Value) propertyEnum() ([]propertyEnum, error) {
+func (v *Value) propertyEnum() ([]propertyEnum, error) {
 	var ptr *C.JSPropertyEnum
 	var size C.uint32_t
 
@@ -306,7 +305,7 @@ func (v Value) propertyEnum() ([]propertyEnum, error) {
 	names := make([]propertyEnum, len(entries))
 	for i := 0; i < len(names); i++ {
 		names[i].IsEnumerable = entries[i].is_enumerable == 1
-		names[i].atom = Atom{ctx: v.ctx, ref: entries[i].atom}
+		names[i].atom = &Atom{ctx: v.ctx, ref: entries[i].atom}
 		names[i].atom.Free()
 	}
 
@@ -314,7 +313,7 @@ func (v Value) propertyEnum() ([]propertyEnum, error) {
 }
 
 // PropertyNames returns the names of the properties of the value.
-func (v Value) PropertyNames() ([]string, error) {
+func (v *Value) PropertyNames() ([]string, error) {
 	pList, err := v.propertyEnum()
 	if err != nil {
 		return nil, err
@@ -327,21 +326,21 @@ func (v Value) PropertyNames() ([]string, error) {
 }
 
 // Has returns true if the value has the property with the given name.
-func (v Value) Has(name string) bool {
+func (v *Value) Has(name string) bool {
 	prop := v.ctx.Atom(name)
 	defer prop.Free()
 	return C.JS_HasProperty(v.ctx.ref, v.ref, prop.ref) == 1
 }
 
 // HasIdx returns true if the value has the property with the given index.
-func (v Value) HasIdx(idx uint32) bool {
+func (v *Value) HasIdx(idx uint32) bool {
 	prop := v.ctx.AtomIdx(idx)
 	defer prop.Free()
 	return C.JS_HasProperty(v.ctx.ref, v.ref, prop.ref) == 1
 }
 
 // Delete deletes the property with the given name.
-func (v Value) Delete(name string) bool {
+func (v *Value) Delete(name string) bool {
 	if !v.Has(name) {
 		return false // Property does not exist, nothing to delete
 	}
@@ -351,7 +350,7 @@ func (v Value) Delete(name string) bool {
 }
 
 // DeleteIdx deletes the property with the given index.
-func (v Value) DeleteIdx(idx uint32) bool {
+func (v *Value) DeleteIdx(idx uint32) bool {
 	if !v.HasIdx(idx) {
 		return false // Property does not exist, nothing to delete
 	}
@@ -359,7 +358,7 @@ func (v Value) DeleteIdx(idx uint32) bool {
 }
 
 // GlobalInstanceof checks if the value is an instance of the given global constructor
-func (v Value) GlobalInstanceof(name string) bool {
+func (v *Value) GlobalInstanceof(name string) bool {
 	ctor := v.ctx.Globals().Get(name)
 	defer ctor.Free()
 	if ctor.IsUndefined() {
@@ -368,45 +367,17 @@ func (v Value) GlobalInstanceof(name string) bool {
 	return C.JS_IsInstanceOf(v.ctx.ref, v.ref, ctor.ref) == 1
 }
 
-// TypedArray detection methods
-func (v Value) IsTypedArray() bool {
-	typedArrayTypes := []string{
-		"Int8Array", "Uint8Array", "Uint8ClampedArray",
-		"Int16Array", "Uint16Array", "Int32Array", "Uint32Array",
-		"Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array",
-	}
-
-	for _, typeName := range typedArrayTypes {
-		if v.GlobalInstanceof(typeName) {
-			return true
-		}
-	}
-	return false
-}
-
-func (v Value) IsInt8Array() bool         { return v.GlobalInstanceof("Int8Array") }
-func (v Value) IsUint8Array() bool        { return v.GlobalInstanceof("Uint8Array") }
-func (v Value) IsUint8ClampedArray() bool { return v.GlobalInstanceof("Uint8ClampedArray") }
-func (v Value) IsInt16Array() bool        { return v.GlobalInstanceof("Int16Array") }
-func (v Value) IsUint16Array() bool       { return v.GlobalInstanceof("Uint16Array") }
-func (v Value) IsInt32Array() bool        { return v.GlobalInstanceof("Int32Array") }
-func (v Value) IsUint32Array() bool       { return v.GlobalInstanceof("Uint32Array") }
-func (v Value) IsFloat32Array() bool      { return v.GlobalInstanceof("Float32Array") }
-func (v Value) IsFloat64Array() bool      { return v.GlobalInstanceof("Float64Array") }
-func (v Value) IsBigInt64Array() bool     { return v.GlobalInstanceof("BigInt64Array") }
-func (v Value) IsBigUint64Array() bool    { return v.GlobalInstanceof("BigUint64Array") }
-
 // getTypedArrayInfo is a helper function to extract TypedArray information using C API
-func (v Value) getTypedArrayInfo() (buffer Value, byteOffset, byteLength, bytesPerElement int) {
+func (v *Value) getTypedArrayInfo() (buffer *Value, byteOffset, byteLength, bytesPerElement int) {
 	var cByteOffset, cByteLength, cBytesPerElement C.size_t
 	bufferRef := C.JS_GetTypedArrayBuffer(v.ctx.ref, v.ref, &cByteOffset, &cByteLength, &cBytesPerElement)
 
-	return Value{ctx: v.ctx, ref: bufferRef},
+	return &Value{ctx: v.ctx, ref: bufferRef},
 		int(cByteOffset), int(cByteLength), int(cBytesPerElement)
 }
 
 // ToInt8Array converts the value to int8 slice if it's an Int8Array.
-func (v Value) ToInt8Array() ([]int8, error) {
+func (v *Value) ToInt8Array() ([]int8, error) {
 	if !v.IsInt8Array() {
 		return nil, errors.New("value is not an Int8Array")
 	}
@@ -429,7 +400,7 @@ func (v Value) ToInt8Array() ([]int8, error) {
 }
 
 // ToUint8Array converts the value to uint8 slice if it's a Uint8Array or Uint8ClampedArray.
-func (v Value) ToUint8Array() ([]uint8, error) {
+func (v *Value) ToUint8Array() ([]uint8, error) {
 	if !v.IsUint8Array() && !v.IsUint8ClampedArray() {
 		return nil, errors.New("value is not a Uint8Array or Uint8ClampedArray")
 	}
@@ -447,7 +418,7 @@ func (v Value) ToUint8Array() ([]uint8, error) {
 }
 
 // ToInt16Array converts the value to int16 slice if it's an Int16Array.
-func (v Value) ToInt16Array() ([]int16, error) {
+func (v *Value) ToInt16Array() ([]int16, error) {
 	if !v.IsInt16Array() {
 		return nil, errors.New("value is not an Int16Array")
 	}
@@ -470,7 +441,7 @@ func (v Value) ToInt16Array() ([]int16, error) {
 }
 
 // ToUint16Array converts the value to uint16 slice if it's a Uint16Array.
-func (v Value) ToUint16Array() ([]uint16, error) {
+func (v *Value) ToUint16Array() ([]uint16, error) {
 	if !v.IsUint16Array() {
 		return nil, errors.New("value is not a Uint16Array")
 	}
@@ -493,7 +464,7 @@ func (v Value) ToUint16Array() ([]uint16, error) {
 }
 
 // ToInt32Array converts the value to int32 slice if it's an Int32Array.
-func (v Value) ToInt32Array() ([]int32, error) {
+func (v *Value) ToInt32Array() ([]int32, error) {
 	if !v.IsInt32Array() {
 		return nil, errors.New("value is not an Int32Array")
 	}
@@ -516,7 +487,7 @@ func (v Value) ToInt32Array() ([]int32, error) {
 }
 
 // ToUint32Array converts the value to uint32 slice if it's a Uint32Array.
-func (v Value) ToUint32Array() ([]uint32, error) {
+func (v *Value) ToUint32Array() ([]uint32, error) {
 	if !v.IsUint32Array() {
 		return nil, errors.New("value is not a Uint32Array")
 	}
@@ -539,7 +510,7 @@ func (v Value) ToUint32Array() ([]uint32, error) {
 }
 
 // ToFloat32Array converts the value to float32 slice if it's a Float32Array.
-func (v Value) ToFloat32Array() ([]float32, error) {
+func (v *Value) ToFloat32Array() ([]float32, error) {
 	if !v.IsFloat32Array() {
 		return nil, errors.New("value is not a Float32Array")
 	}
@@ -563,7 +534,7 @@ func (v Value) ToFloat32Array() ([]float32, error) {
 }
 
 // ToFloat64Array converts the value to float64 slice if it's a Float64Array.
-func (v Value) ToFloat64Array() ([]float64, error) {
+func (v *Value) ToFloat64Array() ([]float64, error) {
 	if !v.IsFloat64Array() {
 		return nil, errors.New("value is not a Float64Array")
 	}
@@ -587,7 +558,7 @@ func (v Value) ToFloat64Array() ([]float64, error) {
 }
 
 // ToBigInt64Array converts the value to int64 slice if it's a BigInt64Array.
-func (v Value) ToBigInt64Array() ([]int64, error) {
+func (v *Value) ToBigInt64Array() ([]int64, error) {
 	if !v.IsBigInt64Array() {
 		return nil, errors.New("value is not a BigInt64Array")
 	}
@@ -610,7 +581,7 @@ func (v Value) ToBigInt64Array() ([]int64, error) {
 }
 
 // ToBigUint64Array converts the value to uint64 slice if it's a BigUint64Array.
-func (v Value) ToBigUint64Array() ([]uint64, error) {
+func (v *Value) ToBigUint64Array() ([]uint64, error) {
 	if !v.IsBigUint64Array() {
 		return nil, errors.New("value is not a BigUint64Array")
 	}
@@ -636,35 +607,35 @@ func (v Value) ToBigUint64Array() ([]uint64, error) {
 // BASIC TYPE CHECKING METHODS (replaced macros with wrapper functions)
 // =============================================================================
 
-func (v Value) IsNumber() bool        { return C.JS_IsNumber_Wrapper(v.ref) == 1 }
-func (v Value) IsBigInt() bool        { return C.JS_IsBigInt_Wrapper(v.ctx.ref, v.ref) == 1 }
-func (v Value) IsBool() bool          { return C.JS_IsBool_Wrapper(v.ref) == 1 }
-func (v Value) IsNull() bool          { return C.JS_IsNull_Wrapper(v.ref) == 1 }
-func (v Value) IsUndefined() bool     { return C.JS_IsUndefined_Wrapper(v.ref) == 1 }
-func (v Value) IsException() bool     { return C.JS_IsException_Wrapper(v.ref) == 1 }
-func (v Value) IsUninitialized() bool { return C.JS_IsUninitialized_Wrapper(v.ref) == 1 }
-func (v Value) IsString() bool        { return C.JS_IsString_Wrapper(v.ref) == 1 }
-func (v Value) IsSymbol() bool        { return C.JS_IsSymbol_Wrapper(v.ref) == 1 }
-func (v Value) IsObject() bool        { return C.JS_IsObject_Wrapper(v.ref) == 1 }
-func (v Value) IsArray() bool         { return C.JS_IsArray(v.ctx.ref, v.ref) == 1 }
-func (v Value) IsError() bool         { return C.JS_IsError(v.ctx.ref, v.ref) == 1 }
-func (v Value) IsFunction() bool      { return C.JS_IsFunction(v.ctx.ref, v.ref) == 1 }
-func (v Value) IsConstructor() bool   { return C.JS_IsConstructor(v.ctx.ref, v.ref) == 1 }
+func (v *Value) IsNumber() bool        { return v != nil && C.JS_IsNumber_Wrapper(v.ref) == 1 }
+func (v *Value) IsBigInt() bool        { return v != nil && C.JS_IsBigInt_Wrapper(v.ctx.ref, v.ref) == 1 }
+func (v *Value) IsBool() bool          { return v != nil && C.JS_IsBool_Wrapper(v.ref) == 1 }
+func (v *Value) IsNull() bool          { return v != nil && C.JS_IsNull_Wrapper(v.ref) == 1 }
+func (v *Value) IsUndefined() bool     { return v != nil && C.JS_IsUndefined_Wrapper(v.ref) == 1 }
+func (v *Value) IsException() bool     { return v != nil && C.JS_IsException_Wrapper(v.ref) == 1 }
+func (v *Value) IsUninitialized() bool { return v != nil && C.JS_IsUninitialized_Wrapper(v.ref) == 1 }
+func (v *Value) IsString() bool        { return v != nil && C.JS_IsString_Wrapper(v.ref) == 1 }
+func (v *Value) IsSymbol() bool        { return v != nil && C.JS_IsSymbol_Wrapper(v.ref) == 1 }
+func (v *Value) IsObject() bool        { return v != nil && C.JS_IsObject_Wrapper(v.ref) == 1 }
+func (v *Value) IsArray() bool         { return v != nil && C.JS_IsArray(v.ctx.ref, v.ref) == 1 }
+func (v *Value) IsError() bool         { return v != nil && C.JS_IsError(v.ctx.ref, v.ref) == 1 }
+func (v *Value) IsFunction() bool      { return v != nil && C.JS_IsFunction(v.ctx.ref, v.ref) == 1 }
+func (v *Value) IsConstructor() bool   { return v != nil && C.JS_IsConstructor(v.ctx.ref, v.ref) == 1 }
 
 // =============================================================================
 // PROMISE SUPPORT METHODS (replaced constants with getter functions)
 // =============================================================================
 
-func (v Value) IsPromise() bool {
+func (v *Value) IsPromise() bool {
+	if v == nil {
+		return false
+	}
 	state := C.JS_PromiseState(v.ctx.ref, v.ref)
 	pending := C.GetPromisePending()
 	fulfilled := C.GetPromiseFulfilled()
 	rejected := C.GetPromiseRejected()
 
-	if C.int(state) == pending || C.int(state) == fulfilled || C.int(state) == rejected {
-		return true
-	}
-	return false
+	return C.int(state) == pending || C.int(state) == fulfilled || C.int(state) == rejected
 }
 
 // Promise state enumeration matching QuickJS
@@ -677,7 +648,7 @@ const (
 )
 
 // PromiseState returns the state of the Promise
-func (v Value) PromiseState() PromiseState {
+func (v *Value) PromiseState() PromiseState {
 	if !v.IsPromise() {
 		return PromisePending
 	}
@@ -695,14 +666,14 @@ func (v Value) PromiseState() PromiseState {
 
 // Await waits for promise resolution and executes pending jobs
 // Similar to Context.Await but called on Value directly
-func (v Value) Await() (Value, error) {
+func (v *Value) Await() (*Value, error) {
 	if !v.IsPromise() {
 		// Not a promise, return as-is
 		return v, nil
 	}
 
 	// Use js_std_await which handles the event loop
-	result := Value{ctx: v.ctx, ref: C.js_std_await(v.ctx.ref, v.ref)}
+	result := &Value{ctx: v.ctx, ref: C.js_std_await(v.ctx.ref, v.ref)}
 	if result.IsException() {
 		return result, v.ctx.Exception()
 	}
@@ -715,16 +686,14 @@ func (v Value) Await() (Value, error) {
 
 // IsClassInstance checks if the value is an instance of any user-defined class
 // This method uses opaque data validation for maximum reliability
-func (v Value) IsClassInstance() bool {
-	// The most reliable method: check for valid opaque data
-	// All our class instances have opaque data pointing to HandleStore entries
-	return v.HasInstanceData()
+func (v *Value) IsClassInstance() bool {
+	return v != nil && v.HasInstanceData()
 }
 
 // HasInstanceData checks if the value has associated Go object data
 // This is the most reliable way to identify our class instances
-func (v Value) HasInstanceData() bool {
-	if !v.IsObject() {
+func (v *Value) HasInstanceData() bool {
+	if v == nil || !v.IsObject() {
 		return false
 	}
 
@@ -745,8 +714,8 @@ func (v Value) HasInstanceData() bool {
 
 // IsInstanceOfClassID checks if the value is an instance of a specific class ID
 // This provides type-safe class instance checking with double validation
-func (v Value) IsInstanceOfClassID(expectedClassID uint32) bool {
-	if !v.IsObject() {
+func (v *Value) IsInstanceOfClassID(expectedClassID uint32) bool {
+	if v == nil || !v.IsObject() {
 		return false
 	}
 
@@ -757,13 +726,13 @@ func (v Value) IsInstanceOfClassID(expectedClassID uint32) bool {
 
 // GetClassID returns the class ID of the value if it's a class instance
 // Returns JS_INVALID_CLASS_ID (0) if not a class instance
-func (v Value) GetClassID() uint32 {
+func (v *Value) GetClassID() uint32 {
 	return uint32(C.JS_GetClassID(v.ref))
 }
 
 // GetGoObject retrieves Go object from JavaScript class instance
 // This method extracts the opaque data stored by the constructor proxy
-func (v Value) GetGoObject() (interface{}, error) {
+func (v *Value) GetGoObject() (interface{}, error) {
 	// First check if the value is an object
 	if !v.IsObject() {
 		return nil, errors.New("value is not an object")
@@ -796,17 +765,52 @@ func (v Value) GetGoObject() (interface{}, error) {
 
 // IsInstanceOfConstructor checks if the value is an instance of a specific constructor
 // This uses JavaScript's instanceof operator semantics
-func (v Value) IsInstanceOfConstructor(constructor Value) bool {
-	if !v.IsObject() || !constructor.IsFunction() {
+func (v *Value) IsInstanceOfConstructor(constructor *Value) bool {
+	return v != nil && constructor != nil && v.IsObject() && constructor.IsFunction() &&
+		C.JS_IsInstanceOf(v.ctx.ref, v.ref, constructor.ref) == 1
+}
+
+// TypedArray detection methods
+func (v *Value) IsTypedArray() bool {
+	if v == nil {
 		return false
 	}
+	typedArrayTypes := []string{
+		"Int8Array", "Uint8Array", "Uint8ClampedArray",
+		"Int16Array", "Uint16Array", "Int32Array", "Uint32Array",
+		"Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array",
+	}
 
-	return C.JS_IsInstanceOf(v.ctx.ref, v.ref, constructor.ref) == 1
+	for _, typeName := range typedArrayTypes {
+		if v.GlobalInstanceof(typeName) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *Value) IsInt8Array() bool  { return v != nil && v.GlobalInstanceof("Int8Array") }
+func (v *Value) IsUint8Array() bool { return v != nil && v.GlobalInstanceof("Uint8Array") }
+func (v *Value) IsUint8ClampedArray() bool {
+	return v != nil && v.GlobalInstanceof("Uint8ClampedArray")
+}
+func (v *Value) IsInt16Array() bool     { return v != nil && v.GlobalInstanceof("Int16Array") }
+func (v *Value) IsUint16Array() bool    { return v != nil && v.GlobalInstanceof("Uint16Array") }
+func (v *Value) IsInt32Array() bool     { return v != nil && v.GlobalInstanceof("Int32Array") }
+func (v *Value) IsUint32Array() bool    { return v != nil && v.GlobalInstanceof("Uint32Array") }
+func (v *Value) IsFloat32Array() bool   { return v != nil && v.GlobalInstanceof("Float32Array") }
+func (v *Value) IsFloat64Array() bool   { return v != nil && v.GlobalInstanceof("Float64Array") }
+func (v *Value) IsBigInt64Array() bool  { return v != nil && v.GlobalInstanceof("BigInt64Array") }
+func (v *Value) IsBigUint64Array() bool { return v != nil && v.GlobalInstanceof("BigUint64Array") }
+
+// IsByteArray returns true if the value is array buffer
+func (v *Value) IsByteArray() bool {
+	return v != nil && v.IsObject() && (v.GlobalInstanceof("ArrayBuffer") || v.String() == "[object ArrayBuffer]")
 }
 
 // resolveClassIDFromInheritance attempts to resolve classID by checking if this constructor
 // extends a registered class and should use the parent's classID
-func (v Value) resolveClassIDFromInheritance() (uint32, bool) {
+func (v *Value) resolveClassIDFromInheritance() (uint32, bool) {
 	// Simple and efficient approach: use JavaScript to traverse the prototype chain
 	script := `
         (function(child) {
@@ -836,7 +840,9 @@ func (v Value) resolveClassIDFromInheritance() (uint32, bool) {
 	defer traverser.Free()
 
 	// Get all parent constructors
-	parents := traverser.Execute(v.ctx.Undefined(), v)
+	undefinedVal := v.ctx.Undefined()
+	defer undefinedVal.Free()
+	parents := traverser.Execute(undefinedVal, v)
 	defer parents.Free()
 
 	// Check each parent to see if it's registered

--- a/value.go
+++ b/value.go
@@ -291,7 +291,7 @@ func (v *Value) ToError() error {
 }
 
 // propertyEnum is a wrapper around JSValue.
-func (v *Value) propertyEnum() ([]propertyEnum, error) {
+func (v *Value) propertyEnum() ([]*propertyEnum, error) {
 	var ptr *C.JSPropertyEnum
 	var size C.uint32_t
 
@@ -302,10 +302,12 @@ func (v *Value) propertyEnum() ([]propertyEnum, error) {
 	defer C.js_free(v.ctx.ref, unsafe.Pointer(ptr))
 
 	entries := unsafe.Slice(ptr, size) // Go 1.17 and later
-	names := make([]propertyEnum, len(entries))
+	names := make([]*propertyEnum, len(entries))
 	for i := 0; i < len(names); i++ {
-		names[i].IsEnumerable = entries[i].is_enumerable == 1
-		names[i].atom = &Atom{ctx: v.ctx, ref: entries[i].atom}
+		names[i] = &propertyEnum{
+			IsEnumerable: entries[i].is_enumerable == 1,
+			atom:         &Atom{ctx: v.ctx, ref: entries[i].atom},
+		}
 		names[i].atom.Free()
 	}
 

--- a/value_test.go
+++ b/value_test.go
@@ -19,17 +19,17 @@ func TestValueBasics(t *testing.T) {
 	// Test basic type creation and checking
 	testCases := []struct {
 		name      string
-		createVal func() Value
-		checkFunc func(Value) bool
+		createVal func() *Value     // Changed to return pointer
+		checkFunc func(*Value) bool // Changed parameter to pointer
 	}{
-		{"Number", func() Value { return ctx.Int32(42) }, func(v Value) bool { return v.IsNumber() }},
-		{"String", func() Value { return ctx.String("test") }, func(v Value) bool { return v.IsString() }},
-		{"Boolean", func() Value { return ctx.Bool(true) }, func(v Value) bool { return v.IsBool() }},
-		{"Null", func() Value { return ctx.Null() }, func(v Value) bool { return v.IsNull() }},
-		{"Undefined", func() Value { return ctx.Undefined() }, func(v Value) bool { return v.IsUndefined() }},
-		{"Uninitialized", func() Value { return ctx.Uninitialized() }, func(v Value) bool { return v.IsUninitialized() }},
-		{"Object", func() Value { return ctx.Object() }, func(v Value) bool { return v.IsObject() }},
-		{"BigInt", func() Value { return ctx.BigInt64(123456789) }, func(v Value) bool { return v.IsBigInt() }},
+		{"Number", func() *Value { return ctx.Int32(42) }, func(v *Value) bool { return v.IsNumber() }},
+		{"String", func() *Value { return ctx.String("test") }, func(v *Value) bool { return v.IsString() }},
+		{"Boolean", func() *Value { return ctx.Bool(true) }, func(v *Value) bool { return v.IsBool() }},
+		{"Null", func() *Value { return ctx.Null() }, func(v *Value) bool { return v.IsNull() }},
+		{"Undefined", func() *Value { return ctx.Undefined() }, func(v *Value) bool { return v.IsUndefined() }},
+		{"Uninitialized", func() *Value { return ctx.Uninitialized() }, func(v *Value) bool { return v.IsUninitialized() }},
+		{"Object", func() *Value { return ctx.Object() }, func(v *Value) bool { return v.IsObject() }},
+		{"BigInt", func() *Value { return ctx.BigInt64(123456789) }, func(v *Value) bool { return v.IsBigInt() }},
 	}
 
 	for _, tc := range testCases {
@@ -64,47 +64,47 @@ func TestValueConversions(t *testing.T) {
 	// Test basic conversions
 	tests := []struct {
 		name           string
-		createVal      func() Value
-		testFunc       func(Value)
-		testDeprecated func(Value) // Test deprecated methods for coverage
+		createVal      func() *Value // Changed to return pointer
+		testFunc       func(*Value)  // Changed parameter to pointer
+		testDeprecated func(*Value)  // Changed parameter to pointer - Test deprecated methods for coverage
 	}{
 		{
 			name:           "Bool",
-			createVal:      func() Value { return ctx.Bool(true) },
-			testFunc:       func(v Value) { require.True(t, v.ToBool()) },
-			testDeprecated: func(v Value) { require.True(t, v.Bool()) },
+			createVal:      func() *Value { return ctx.Bool(true) },
+			testFunc:       func(v *Value) { require.True(t, v.ToBool()) },
+			testDeprecated: func(v *Value) { require.True(t, v.Bool()) },
 		},
 		{
 			name:      "String",
-			createVal: func() Value { return ctx.String("Hello") },
-			testFunc: func(v Value) {
+			createVal: func() *Value { return ctx.String("Hello") },
+			testFunc: func(v *Value) {
 				require.Equal(t, "Hello", v.ToString())
 				require.Equal(t, "Hello", v.String()) // String() calls ToString()
 			},
 		},
 		{
 			name:           "Int32",
-			createVal:      func() Value { return ctx.Int32(42) },
-			testFunc:       func(v Value) { require.Equal(t, int32(42), v.ToInt32()) },
-			testDeprecated: func(v Value) { require.Equal(t, int32(42), v.Int32()) },
+			createVal:      func() *Value { return ctx.Int32(42) },
+			testFunc:       func(v *Value) { require.Equal(t, int32(42), v.ToInt32()) },
+			testDeprecated: func(v *Value) { require.Equal(t, int32(42), v.Int32()) },
 		},
 		{
 			name:           "Int64",
-			createVal:      func() Value { return ctx.Int64(1234567890) },
-			testFunc:       func(v Value) { require.Equal(t, int64(1234567890), v.ToInt64()) },
-			testDeprecated: func(v Value) { require.Equal(t, int64(1234567890), v.Int64()) },
+			createVal:      func() *Value { return ctx.Int64(1234567890) },
+			testFunc:       func(v *Value) { require.Equal(t, int64(1234567890), v.ToInt64()) },
+			testDeprecated: func(v *Value) { require.Equal(t, int64(1234567890), v.Int64()) },
 		},
 		{
 			name:           "Uint32",
-			createVal:      func() Value { return ctx.Uint32(4294967295) },
-			testFunc:       func(v Value) { require.Equal(t, uint32(4294967295), v.ToUint32()) },
-			testDeprecated: func(v Value) { require.Equal(t, uint32(4294967295), v.Uint32()) },
+			createVal:      func() *Value { return ctx.Uint32(4294967295) },
+			testFunc:       func(v *Value) { require.Equal(t, uint32(4294967295), v.ToUint32()) },
+			testDeprecated: func(v *Value) { require.Equal(t, uint32(4294967295), v.Uint32()) },
 		},
 		{
 			name:           "Float64",
-			createVal:      func() Value { return ctx.Float64(3.14159) },
-			testFunc:       func(v Value) { require.InDelta(t, 3.14159, v.ToFloat64(), 0.00001) },
-			testDeprecated: func(v Value) { require.InDelta(t, 3.14159, v.Float64(), 0.00001) },
+			createVal:      func() *Value { return ctx.Float64(3.14159) },
+			testFunc:       func(v *Value) { require.InDelta(t, 3.14159, v.ToFloat64(), 0.00001) },
+			testDeprecated: func(v *Value) { require.InDelta(t, 3.14159, v.Float64(), 0.00001) },
 		},
 	}
 
@@ -153,14 +153,14 @@ func TestValueJSON(t *testing.T) {
 	// Test various value types
 	testCases := []struct {
 		name      string
-		createVal func() Value
+		createVal func() *Value // Changed to return pointer
 		expected  string
 	}{
-		{"String", func() Value { return ctx.String("hello") }, `"hello"`},
-		{"Null", func() Value { return ctx.Null() }, "null"},
-		{"True", func() Value { return ctx.Bool(true) }, "true"},
-		{"False", func() Value { return ctx.Bool(false) }, "false"},
-		{"Number", func() Value { return ctx.Int32(42) }, "42"},
+		{"String", func() *Value { return ctx.String("hello") }, `"hello"`},
+		{"Null", func() *Value { return ctx.Null() }, "null"},
+		{"True", func() *Value { return ctx.Bool(true) }, "true"},
+		{"False", func() *Value { return ctx.Bool(false) }, "false"},
+		{"Number", func() *Value { return ctx.Int32(42) }, "42"},
 	}
 
 	for _, tc := range testCases {
@@ -208,12 +208,12 @@ func TestValueArrayBuffer(t *testing.T) {
 	// Test error cases with non-ArrayBuffer types
 	errorTests := []struct {
 		name      string
-		createVal func() Value
+		createVal func() *Value // Changed to return pointer
 	}{
-		{"Object", func() Value { return ctx.Object() }},
-		{"String", func() Value { return ctx.String("not an array buffer") }},
-		{"Number", func() Value { return ctx.Int32(42) }},
-		{"Null", func() Value { return ctx.Null() }},
+		{"Object", func() *Value { return ctx.Object() }},
+		{"String", func() *Value { return ctx.String("not an array buffer") }},
+		{"Number", func() *Value { return ctx.Int32(42) }},
+		{"Null", func() *Value { return ctx.Null() }},
 	}
 
 	for _, tt := range errorTests {
@@ -237,21 +237,21 @@ func TestValueTypedArrays(t *testing.T) {
 	typedArrayTests := []struct {
 		name      string
 		jsCode    string
-		checkFunc func(Value) bool
+		checkFunc func(*Value) bool // Changed parameter to pointer
 		isTyped   bool
 	}{
-		{"Int8Array", "new Int8Array([1, 2, 3])", func(v Value) bool { return v.IsInt8Array() }, true},
-		{"Uint8Array", "new Uint8Array([1, 2, 3])", func(v Value) bool { return v.IsUint8Array() }, true},
-		{"Uint8ClampedArray", "new Uint8ClampedArray([1, 2, 3])", func(v Value) bool { return v.IsUint8ClampedArray() }, true},
-		{"Int16Array", "new Int16Array([1, 2, 3])", func(v Value) bool { return v.IsInt16Array() }, true},
-		{"Uint16Array", "new Uint16Array([1, 2, 3])", func(v Value) bool { return v.IsUint16Array() }, true},
-		{"Int32Array", "new Int32Array([1, 2, 3])", func(v Value) bool { return v.IsInt32Array() }, true},
-		{"Uint32Array", "new Uint32Array([1, 2, 3])", func(v Value) bool { return v.IsUint32Array() }, true},
-		{"Float32Array", "new Float32Array([1.5, 2.5, 3.5])", func(v Value) bool { return v.IsFloat32Array() }, true},
-		{"Float64Array", "new Float64Array([1.5, 2.5, 3.5])", func(v Value) bool { return v.IsFloat64Array() }, true},
-		{"BigInt64Array", "new BigInt64Array([1n, 2n, 3n])", func(v Value) bool { return v.IsBigInt64Array() }, true},
-		{"BigUint64Array", "new BigUint64Array([1n, 2n, 3n])", func(v Value) bool { return v.IsBigUint64Array() }, true},
-		{"RegularArray", "[1, 2, 3]", func(v Value) bool { return v.IsInt8Array() }, false},
+		{"Int8Array", "new Int8Array([1, 2, 3])", func(v *Value) bool { return v.IsInt8Array() }, true},
+		{"Uint8Array", "new Uint8Array([1, 2, 3])", func(v *Value) bool { return v.IsUint8Array() }, true},
+		{"Uint8ClampedArray", "new Uint8ClampedArray([1, 2, 3])", func(v *Value) bool { return v.IsUint8ClampedArray() }, true},
+		{"Int16Array", "new Int16Array([1, 2, 3])", func(v *Value) bool { return v.IsInt16Array() }, true},
+		{"Uint16Array", "new Uint16Array([1, 2, 3])", func(v *Value) bool { return v.IsUint16Array() }, true},
+		{"Int32Array", "new Int32Array([1, 2, 3])", func(v *Value) bool { return v.IsInt32Array() }, true},
+		{"Uint32Array", "new Uint32Array([1, 2, 3])", func(v *Value) bool { return v.IsUint32Array() }, true},
+		{"Float32Array", "new Float32Array([1.5, 2.5, 3.5])", func(v *Value) bool { return v.IsFloat32Array() }, true},
+		{"Float64Array", "new Float64Array([1.5, 2.5, 3.5])", func(v *Value) bool { return v.IsFloat64Array() }, true},
+		{"BigInt64Array", "new BigInt64Array([1n, 2n, 3n])", func(v *Value) bool { return v.IsBigInt64Array() }, true},
+		{"BigUint64Array", "new BigUint64Array([1n, 2n, 3n])", func(v *Value) bool { return v.IsBigUint64Array() }, true},
+		{"RegularArray", "[1, 2, 3]", func(v *Value) bool { return v.IsInt8Array() }, false},
 	}
 
 	for _, tt := range typedArrayTests {
@@ -273,37 +273,37 @@ func TestValueTypedArrays(t *testing.T) {
 	conversionTests := []struct {
 		name        string
 		jsCode      string
-		convertFunc func(Value) (interface{}, error)
+		convertFunc func(*Value) (interface{}, error) // Changed parameter to pointer
 		expected    interface{}
 	}{
 		{
 			name:        "Int8Array",
 			jsCode:      "new Int8Array([-128, 0, 127])",
-			convertFunc: func(v Value) (interface{}, error) { return v.ToInt8Array() },
+			convertFunc: func(v *Value) (interface{}, error) { return v.ToInt8Array() },
 			expected:    []int8{-128, 0, 127},
 		},
 		{
 			name:        "Uint8Array",
 			jsCode:      "new Uint8Array([0, 128, 255])",
-			convertFunc: func(v Value) (interface{}, error) { return v.ToUint8Array() },
+			convertFunc: func(v *Value) (interface{}, error) { return v.ToUint8Array() },
 			expected:    []uint8{0, 128, 255},
 		},
 		{
 			name:        "Int32Array",
 			jsCode:      "new Int32Array([-2147483648, 0, 2147483647])",
-			convertFunc: func(v Value) (interface{}, error) { return v.ToInt32Array() },
+			convertFunc: func(v *Value) (interface{}, error) { return v.ToInt32Array() },
 			expected:    []int32{-2147483648, 0, 2147483647},
 		},
 		{
 			name:        "Float32Array",
 			jsCode:      "new Float32Array([1.5, 2.5, 3.14159])",
-			convertFunc: func(v Value) (interface{}, error) { return v.ToFloat32Array() },
+			convertFunc: func(v *Value) (interface{}, error) { return v.ToFloat32Array() },
 			expected:    []float32{1.5, 2.5, 3.14159},
 		},
 		{
 			name:        "BigInt64Array",
 			jsCode:      "new BigInt64Array([-9223372036854775808n, 0n, 9223372036854775807n])",
-			convertFunc: func(v Value) (interface{}, error) { return v.ToBigInt64Array() },
+			convertFunc: func(v *Value) (interface{}, error) { return v.ToBigInt64Array() },
 			expected:    []int64{-9223372036854775808, 0, 9223372036854775807},
 		},
 	}
@@ -340,29 +340,29 @@ func TestValueTypedArrays(t *testing.T) {
 	additionalTests := []struct {
 		name   string
 		jsCode string
-		testFn func(Value)
+		testFn func(*Value) // Changed parameter to pointer
 	}{
-		{"Uint8ClampedArray", "new Uint8ClampedArray([0, 128, 255])", func(v Value) {
+		{"Uint8ClampedArray", "new Uint8ClampedArray([0, 128, 255])", func(v *Value) {
 			result, err := v.ToUint8Array() // Uint8ClampedArray uses same method
 			require.NoError(t, err)
 			require.Equal(t, []uint8{0, 128, 255}, result)
 		}},
-		{"Uint16Array", "new Uint16Array([0, 32768, 65535])", func(v Value) {
+		{"Uint16Array", "new Uint16Array([0, 32768, 65535])", func(v *Value) {
 			result, err := v.ToUint16Array()
 			require.NoError(t, err)
 			require.Equal(t, []uint16{0, 32768, 65535}, result)
 		}},
-		{"Int16Array", "new Int16Array([-32768, 0, 32767])", func(v Value) {
+		{"Int16Array", "new Int16Array([-32768, 0, 32767])", func(v *Value) {
 			result, err := v.ToInt16Array()
 			require.NoError(t, err)
 			require.Equal(t, []int16{-32768, 0, 32767}, result)
 		}},
-		{"Uint32Array", "new Uint32Array([0, 2147483648, 4294967295])", func(v Value) {
+		{"Uint32Array", "new Uint32Array([0, 2147483648, 4294967295])", func(v *Value) {
 			result, err := v.ToUint32Array()
 			require.NoError(t, err)
 			require.Equal(t, []uint32{0, 2147483648, 4294967295}, result)
 		}},
-		{"Float64Array", "new Float64Array([1.5, 2.5, 3.141592653589793])", func(v Value) {
+		{"Float64Array", "new Float64Array([1.5, 2.5, 3.141592653589793])", func(v *Value) {
 			result, err := v.ToFloat64Array()
 			require.NoError(t, err)
 			expected := []float64{1.5, 2.5, 3.141592653589793}
@@ -371,7 +371,7 @@ func TestValueTypedArrays(t *testing.T) {
 				require.InDelta(t, exp, result[i], 1e-10)
 			}
 		}},
-		{"BigUint64Array", "new BigUint64Array([0n, 9223372036854775808n, 18446744073709551615n])", func(v Value) {
+		{"BigUint64Array", "new BigUint64Array([0n, 9223372036854775808n, 18446744073709551615n])", func(v *Value) {
 			result, err := v.ToBigUint64Array()
 			require.NoError(t, err)
 			require.Equal(t, []uint64{0, 9223372036854775808, 18446744073709551615}, result)
@@ -451,8 +451,8 @@ func TestValueFunctionCalls(t *testing.T) {
 	obj := ctx.Object()
 	defer obj.Free()
 
-	// Test function calls
-	addFunc := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+	// Test function calls - UPDATED: function signature now uses pointers
+	addFunc := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 		if len(args) < 2 {
 			return ctx.Int32(0)
 		}
@@ -466,7 +466,7 @@ func TestValueFunctionCalls(t *testing.T) {
 	require.Equal(t, int32(7), result.ToInt32())
 
 	// Call without arguments (covers len(cargs) == 0 branch)
-	noArgsFunc := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+	noArgsFunc := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 		return ctx.String("no arguments")
 	})
 	obj.Set("noArgs", noArgsFunc)
@@ -574,12 +574,12 @@ func TestValueInstanceof(t *testing.T) {
 	// Test false cases to ensure coverage
 	testVals := []struct {
 		name      string
-		createVal func() Value
+		createVal func() *Value // Changed to return pointer
 	}{
-		{"String", func() Value { return ctx.String("test") }},
-		{"Number", func() Value { return ctx.Int32(42) }},
-		{"Null", func() Value { return ctx.Null() }},
-		{"Undefined", func() Value { return ctx.Undefined() }},
+		{"String", func() *Value { return ctx.String("test") }},
+		{"Number", func() *Value { return ctx.Int32(42) }},
+		{"Null", func() *Value { return ctx.Null() }},
+		{"Undefined", func() *Value { return ctx.Undefined() }},
 	}
 
 	for _, tv := range testVals {
@@ -600,8 +600,8 @@ func TestValueSpecialTypes(t *testing.T) {
 	ctx := rt.NewContext()
 	defer ctx.Close()
 
-	// Test function
-	funcVal := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+	// Test function - UPDATED: function signature now uses pointers
+	funcVal := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 		return ctx.Null()
 	})
 	defer funcVal.Free()
@@ -636,11 +636,11 @@ func TestValueSpecialTypes(t *testing.T) {
 	// Test non-Promise objects for IsPromise method (covers return false branch)
 	nonPromiseTests := []struct {
 		name      string
-		createVal func() Value
+		createVal func() *Value // Changed to return pointer
 	}{
-		{"Object", func() Value { return ctx.Object() }},
-		{"String", func() Value { return ctx.String("not a promise") }},
-		{"Number", func() Value { return ctx.Int32(42) }},
+		{"Object", func() *Value { return ctx.Object() }},
+		{"String", func() *Value { return ctx.String("not a promise") }},
+		{"Number", func() *Value { return ctx.Int32(42) }},
 	}
 
 	for _, tt := range nonPromiseTests {
@@ -671,6 +671,12 @@ func TestValueSpecialTypes(t *testing.T) {
 	require.NoError(t, err)
 	defer nanVal.Free()
 	require.True(t, nanVal.IsNumber())
+
+	// Test nil value for special type checks
+	var nilValue *Value
+	require.False(t, nilValue.IsPromise(), "nil value should not be a promise")
+	require.False(t, nilValue.IsTypedArray(), "nil value should not be a typed array")
+
 }
 
 // TestPromiseState tests promise state handling
@@ -756,12 +762,12 @@ func TestValueClassInstanceEdgeCases(t *testing.T) {
 	// Test non-object values to cover !v.IsObject() branches
 	nonObjects := []struct {
 		name      string
-		createVal func() Value
+		createVal func() *Value // Changed to return pointer
 	}{
-		{"String", func() Value { return ctx.String("test") }},
-		{"Number", func() Value { return ctx.Int32(42) }},
-		{"Null", func() Value { return ctx.Null() }},
-		{"Undefined", func() Value { return ctx.Undefined() }},
+		{"String", func() *Value { return ctx.String("test") }},
+		{"Number", func() *Value { return ctx.Int32(42) }},
+		{"Null", func() *Value { return ctx.Null() }},
+		{"Undefined", func() *Value { return ctx.Undefined() }},
 	}
 
 	for _, no := range nonObjects {
@@ -792,7 +798,7 @@ func TestValueClassInstanceEdgeCases(t *testing.T) {
 			val := no.createVal()
 			defer val.Free()
 
-			fn := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+			fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 				return ctx.Null()
 			})
 			defer fn.Free()
@@ -819,7 +825,7 @@ func TestValueClassInstanceEdgeCases(t *testing.T) {
 		obj := ctx.Object()
 		defer obj.Free()
 
-		fn := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			return ctx.Null()
 		})
 		defer fn.Free()
@@ -831,7 +837,7 @@ func TestValueClassInstanceEdgeCases(t *testing.T) {
 	// Test GetGoObject "instance data not found in handle store" branch
 	t.Run("GetGoObject_HandleStoreManipulation", func(t *testing.T) {
 		// Create a function to get a valid object with opaque data
-		fn := ctx.Function(func(ctx *Context, this Value, args []Value) Value {
+		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			return ctx.String("test")
 		})
 		defer fn.Free()
@@ -914,12 +920,12 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 	t.Run("CallConstructor_VariousNonConstructors", func(t *testing.T) {
 		testCases := []struct {
 			name string
-			val  func() Value
+			val  func() *Value // Changed to return pointer
 		}{
-			{"Number", func() Value { return ctx.Int32(42) }},
-			{"Boolean", func() Value { return ctx.Bool(true) }},
-			{"Null", func() Value { return ctx.Null() }},
-			{"Undefined", func() Value { return ctx.Undefined() }},
+			{"Number", func() *Value { return ctx.Int32(42) }},
+			{"Boolean", func() *Value { return ctx.Bool(true) }},
+			{"Null", func() *Value { return ctx.Null() }},
+			{"Undefined", func() *Value { return ctx.Undefined() }},
 		}
 
 		for _, tc := range testCases {
@@ -1030,14 +1036,14 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 		builtInTests := []struct {
 			name     string
 			jsCode   string
-			args     []Value
-			validate func(Value)
+			args     []*Value     // Changed to slice of pointers
+			validate func(*Value) // Changed parameter to pointer
 		}{
 			{
 				name:   "Array",
 				jsCode: "Array",
-				args:   []Value{ctx.Int32(3)},
-				validate: func(v Value) {
+				args:   []*Value{ctx.Int32(3)},
+				validate: func(v *Value) {
 					require.True(t, v.IsArray())
 					require.Equal(t, int64(3), v.Len())
 				},
@@ -1046,7 +1052,7 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 				name:   "Object",
 				jsCode: "Object",
 				args:   nil,
-				validate: func(v Value) {
+				validate: func(v *Value) {
 					require.True(t, v.IsObject())
 					require.False(t, v.IsArray())
 				},
@@ -1054,8 +1060,8 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 			{
 				name:   "Date",
 				jsCode: "Date",
-				args:   []Value{ctx.String("2023-01-01")},
-				validate: func(v Value) {
+				args:   []*Value{ctx.String("2023-01-01")},
+				validate: func(v *Value) {
 					require.True(t, v.IsObject())
 					// Date objects have getTime method
 					getTime := v.Get("getTime")
@@ -1071,7 +1077,7 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 				require.NoError(t, err)
 				defer constructor.Free()
 
-				var result Value
+				var result *Value
 				if len(tt.args) > 0 {
 					result = constructor.CallConstructor(tt.args...)
 				} else {
@@ -1087,9 +1093,9 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 
 	// Test Case 9: Successful CallConstructor with registered class (for comparison)
 	t.Run("CallConstructor_RegisteredClass", func(t *testing.T) {
-		// Create a Point class using our class system
+		// Create a Point class using our class system - UPDATED: constructor signature now uses pointers
 		pointConstructor, _, err := NewClassBuilder("Point").
-			Constructor(func(ctx *Context, instance Value, args []Value) (interface{}, error) {
+			Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
 				x, y := 0.0, 0.0
 				if len(args) > 0 {
 					x = args[0].Float64()
@@ -1102,7 +1108,7 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 				point := &Point{X: x, Y: y}
 				return point, nil
 			}).
-			Method("norm", func(ctx *Context, this Value, args []Value) Value {
+			Method("norm", func(ctx *Context, this *Value, args []*Value) *Value {
 				obj, err := this.GetGoObject()
 				if err != nil {
 					return ctx.ThrowError(err)
@@ -1337,7 +1343,7 @@ func TestValueCallConstructorComprehensive(t *testing.T) {
 
 		// Create multiple instances to test performance
 		const numInstances = 100
-		instances := make([]Value, numInstances)
+		instances := make([]*Value, numInstances) // Changed to slice of pointers
 
 		for i := 0; i < numInstances; i++ {
 			instances[i] = constructor.CallConstructor(ctx.Int32(int32(i)))


### PR DESCRIPTION
BREAKING CHANGE: Value methods now use *Value receivers instead of Value receivers

- Changed all Value method receivers from value to pointer type
- Updated return types from Value to *Value across the codebase
- Modified function signatures in Context, ClassBuilder, and callbacks
- Updated documentation and examples to reflect pointer usage
- Improved memory efficiency by avoiding struct copying