### PR TITLE
feat(error): include cause in Error string output

### DIFF
--- a/error.go
+++ b/error.go
@@ -13,5 +13,8 @@ type Error struct {
 
 // Error implements the error interface.
 func (err *Error) Error() string {
+	if err.Cause != "" {
+		return fmt.Sprintf("%s: %s (cause: %s)", err.Name, err.Message, err.Cause)
+	}
 	return fmt.Sprintf("%s: %s", err.Name, err.Message)
 }

--- a/error.go
+++ b/error.go
@@ -13,8 +13,9 @@ type Error struct {
 
 // Error implements the error interface.
 func (err *Error) Error() string {
+	msg := fmt.Sprintf("%s: %s", err.Name, err.Message)
 	if err.Cause != "" {
-		return fmt.Sprintf("%s: %s (cause: %s)", err.Name, err.Message, err.Cause)
+		return fmt.Sprintf("%s (cause: %s)", msg, err.Cause)
 	}
-	return fmt.Sprintf("%s: %s", err.Name, err.Message)
+	return msg
 }

--- a/error_test.go
+++ b/error_test.go
@@ -19,7 +19,7 @@ func TestErrorBasics(t *testing.T) {
 	}
 
 	// Test Error() method format
-	require.EqualValues(t, "TestError: test message", err.Error())
+	require.EqualValues(t, "TestError: test message (cause: test cause)", err.Error())
 
 	// Test all fields are accessible
 	require.EqualValues(t, "TestError", err.Name)
@@ -192,7 +192,7 @@ func TestErrorFieldManipulation(t *testing.T) {
 	err.JSONString = `{"modified": true}`
 
 	// Test after modification
-	require.EqualValues(t, "ModifiedError: modified message", err.Error())
+	require.EqualValues(t, "ModifiedError: modified message (cause: new cause)", err.Error())
 	require.EqualValues(t, "ModifiedError", err.Name)
 	require.EqualValues(t, "modified message", err.Message)
 	require.EqualValues(t, "new cause", err.Cause)


### PR DESCRIPTION
- Update Error.Error() to append cause information when present
- Improves error diagnostics for JavaScript errors with cause