### PR TITLE
Add context-level scheduler and true async Promise support

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -16,6 +16,7 @@ JSValue JS_NewUninitialized() { return JS_UNINITIALIZED; }
 JSValue JS_NewException() { return JS_EXCEPTION; }
 JSValue JS_NewTrue() { return JS_TRUE; }
 JSValue JS_NewFalse() { return JS_FALSE; }
+JSValue JS_DupValue_Go(JSContext *ctx, JSValue v) { return JS_DupValue(ctx, v); }
 
 // Error throwing macros -> functions
 JSValue ThrowSyntaxError(JSContext *ctx, const char *fmt) { return JS_ThrowSyntaxError(ctx, "%s", fmt); }

--- a/bridge.h
+++ b/bridge.h
@@ -12,6 +12,7 @@ extern JSValue JS_NewUninitialized();
 extern JSValue JS_NewException();
 extern JSValue JS_NewTrue();
 extern JSValue JS_NewFalse();
+extern JSValue JS_DupValue_Go(JSContext *ctx, JSValue v);
 
 // Error throwing functions
 extern JSValue ThrowSyntaxError(JSContext *ctx, const char *fmt);

--- a/runtime.go
+++ b/runtime.go
@@ -260,6 +260,7 @@ func (r *Runtime) NewContext() *Context {
 		runtime:     r,
 		handleStore: newHandleStore(), // Initialize HandleStore for function management
 	}
+	ctx.initScheduler()
 
 	// Register context mapping for C callbacks
 	registerContext(ctx_ref, ctx)


### PR DESCRIPTION
- Implement per-Context scheduler (Schedule, ProcessJobs, drainJobs) and integrate job pumping into Context.Loop / Context.Await so Go-scheduled work runs on the JS thread.
- Update Context.NewPromise to support both synchronous and asynchronous executors. Provide examples and docs: immediate resolve/reject and goroutine + ctx.Schedule pattern. Add note: do not access Context from goroutines; only access QuickJS APIs inside functions passed to ctx.Schedule which run on the context thread.
- Make Await drive QuickJS pending-job loop (js_std_loop / JS_ExecutePendingJob) and consume scheduled Go jobs; add test hooks to exercise edge branches.
- Add wrapPromiseCallback and safe lifetime management for promise callbacks; ensure only the first resolve/reject wins and handlers are released appropriately.
- Expose/adjust necessary bridge functions for value duplication across scheduling boundaries.
- Update tests (context_test.go, quickjs_test.go) to cover async flows, scheduler behavior, and Await edge cases; increase coverage to 100% for Await-related branches.
- Update documentation (README.md, README_zh-cn.md) with canonical async Promise examples and safety guidance; clarify that ctx.Await drives pending jobs so explicit ctx.Loop is not needed when awaiting a Promise.
- Minor fixes and refactors for compatibility with new API surface and test stability.

Files changed: context.go, context_test.go, quickjs_test.go, README.md, README_zh-cn.md, bridge.c/h, runtime.go, and related test/support helpers.