### PR TITLE
fix(module): prevent double-free when initializing native module exports

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -154,6 +154,7 @@ func getContextAndModuleBuilder(ctx *C.JSContext, m *C.JSModuleDef) (*Context, *
 	// Extract ModuleBuilder ID from private value using JS_ToInt32
 	var builderID C.int32_t
 	C.JS_ToInt32(ctx, &builderID, privateValue)
+	C.JS_FreeValue(ctx, privateValue)
 
 	goCtx, builderInterface, err := getContextAndObject(ctx, C.int(builderID), errFunctionNotFound)
 	if err != nil {
@@ -495,7 +496,7 @@ func goModuleInitProxy(ctx *C.JSContext, m *C.JSModuleDef) C.int {
 		export.Value.ref = C.JS_NewUndefined()
 		C.free(unsafe.Pointer(exportName))
 		if rc < 0 {
-			return C.int(-1)
+			return throwModuleError(ctx, fmt.Errorf("failed to set module export: %s", export.Name))
 		}
 	}
 


### PR DESCRIPTION
QuickJS JS_SetModuleExport takes ownership of the JSValue passed in. We were passing Go-owned values directly, which could later be freed again on the Go side, leading to intermittent ref_count assertion failures during JS_FreeRuntime (issue #688).

After handing an export value to JS_SetModuleExport, invalidate the Go Value so subsequent Free() becomes a no-op. Also release the duplicated module private value and propagate export init failures.

Add a regression stress test that runs the minimal repro scenario 50 times.