### PR TITLE
Fix runtime/context lifecycle and interrupt cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Go bindings to QuickJS: a fast, small, and embeddable ES2020 JavaScript interpre
 
 ### Performance Tips
 - QuickJS is not thread-safe. For concurrency or isolation, use a thread pool pattern with pre-initialized runtimes, or manage separate Runtime/Context instances for different tasks or users (such as : [https://github.com/buke/js-executor](https://github.com/buke/js-executor)).
+- Thread affinity is the caller's responsibility. This library no longer calls `runtime.LockOSThread()` / `runtime.UnlockOSThread()` internally.
+- For a given Runtime and its Contexts, create, use, and close them from one serialized owner goroutine. If you need strict OS-thread affinity, call `runtime.LockOSThread()` in that owner goroutine yourself before creating the Runtime.
 - Reuse Runtime and Context objects when possible.
 - Avoid frequent conversion between Go and JS values.
 - Consider using bytecode compilation for frequently executed scripts.
@@ -65,11 +67,15 @@ package main
 
 import (
     "fmt"
+    "runtime"
 
     "github.com/buke/quickjs-go"
 )
 
 func main() {
+    runtime.LockOSThread()
+    defer runtime.UnlockOSThread()
+
     // Create a new runtime
     rt := quickjs.NewRuntime()
     defer rt.Close()
@@ -256,6 +262,8 @@ func main() {
 }
 
 // NOTE:
+// - The caller owns thread affinity. Bind the owner goroutine with runtime.LockOSThread()
+//   yourself if the Runtime must stay on one OS thread.
 // - Goroutines must NOT call QuickJS/Context APIs directly.
 // - Always schedule back to the Context thread via ctx.Schedule
 //   before creating values or resolving/rejecting Promises.

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -42,6 +42,8 @@ Go 语言的 QuickJS 绑定库：快速、小型、可嵌入的 ES2020 JavaScrip
 
 ### 性能建议
 - QuickJS 不是线程安全的。如需并发或隔离，建议使用线程池模式预初始化运行时，或为不同任务/用户管理独立的 Runtime/Context 实例（推荐使用：[https://github.com/buke/js-executor](https://github.com/buke/js-executor)）。
+- 线程归属由调用方自己负责。当前库不再在内部偷偷调用 `runtime.LockOSThread()` / `runtime.UnlockOSThread()`。
+- 对同一个 Runtime 及其 Context，创建、使用和关闭都应由同一个串行 owner goroutine 负责。如果你需要严格的 OS 线程绑定，请在这个 owner goroutine 里先自行调用 `runtime.LockOSThread()`，再创建 Runtime。
 - 尽可能复用 Runtime 和 Context 对象
 - 避免频繁在 Go 和 JS 值之间转换
 - 对于频繁执行的脚本建议使用字节码编译
@@ -64,11 +66,15 @@ package main
 
 import (
     "fmt"
+    "runtime"
 
     "github.com/buke/quickjs-go"
 )
 
 func main() {
+    runtime.LockOSThread()
+    defer runtime.UnlockOSThread()
+
     // 创建新的运行时
     rt := quickjs.NewRuntime()
     defer rt.Close()
@@ -255,6 +261,7 @@ func main() {
 }
 
 // 注意：
+// - 线程归属由调用方负责；如果一个 Runtime 必须固定在同一个 OS 线程，请由调用方自行在 owner goroutine 中调用 runtime.LockOSThread()。
 // - 不要在 goroutine 中直接调用 Context 或任何 QuickJS API。
 // - 所有 QuickJS 相关操作都应该通过 ctx.Schedule 调度回 Context 线程后再执行。
 // - ctx.Await 会在内部驱动 pending jobs 和调度器，直至 Promise 解决。

--- a/bridge.c
+++ b/bridge.c
@@ -2,6 +2,7 @@
 #include "quickjs.h"
 #include "quickjs-libc.h"
 #include "cutils.h" 
+#include <pthread.h>
 #include <time.h>
 
 // ============================================================================
@@ -522,14 +523,14 @@ int interruptHandler(JSRuntime *rt, void *opaque) {
 }
 
 void SetInterruptHandler(JSRuntime *rt) {
-    clearTimeoutState(rt);
     // Use rt itself as opaque parameter for Go lookup
     JS_SetInterruptHandler(rt, interruptHandler, (void*)rt);
+    clearTimeoutState(rt);
 }
 
 void ClearInterruptHandler(JSRuntime *rt) {
-    clearTimeoutState(rt);
     JS_SetInterruptHandler(rt, NULL, NULL);
+    clearTimeoutState(rt);
 }
 
 // Timeout handler implementation (unchanged but improved cleanup)
@@ -545,8 +546,11 @@ typedef struct TimeoutStateEntry {
 } TimeoutStateEntry;
 
 static TimeoutStateEntry *g_timeout_states = NULL;
+static pthread_mutex_t g_timeout_states_mu = PTHREAD_MUTEX_INITIALIZER;
 
 static TimeoutStruct *takeTimeoutState(JSRuntime *rt) {
+    pthread_mutex_lock(&g_timeout_states_mu);
+
     TimeoutStateEntry *prev = NULL;
     TimeoutStateEntry *current = g_timeout_states;
     while (current) {
@@ -558,32 +562,45 @@ static TimeoutStruct *takeTimeoutState(JSRuntime *rt) {
                 g_timeout_states = current->next;
             }
             free(current);
+            pthread_mutex_unlock(&g_timeout_states_mu);
             return state;
         }
         prev = current;
         current = current->next;
     }
+
+    pthread_mutex_unlock(&g_timeout_states_mu);
     return NULL;
 }
 
-static void setTimeoutState(JSRuntime *rt, TimeoutStruct *state) {
+static int setTimeoutState(JSRuntime *rt, TimeoutStruct *state) {
+    pthread_mutex_lock(&g_timeout_states_mu);
+
     TimeoutStateEntry *current = g_timeout_states;
     while (current) {
         if (current->rt == rt) {
+            if (current->state != NULL && current->state != state) {
+                free(current->state);
+            }
             current->state = state;
-            return;
+            pthread_mutex_unlock(&g_timeout_states_mu);
+            return 0;
         }
         current = current->next;
     }
 
     TimeoutStateEntry *entry = malloc(sizeof(TimeoutStateEntry));
     if (!entry) {
-        return;
+        pthread_mutex_unlock(&g_timeout_states_mu);
+        return -1;
     }
     entry->rt = rt;
     entry->state = state;
     entry->next = g_timeout_states;
     g_timeout_states = entry;
+
+    pthread_mutex_unlock(&g_timeout_states_mu);
+    return 0;
 }
 
 static void clearTimeoutState(JSRuntime *rt) {
@@ -595,6 +612,8 @@ static void clearTimeoutState(JSRuntime *rt) {
 
 int GetTimeoutOpaqueCount(void) {
     int count = 0;
+
+    pthread_mutex_lock(&g_timeout_states_mu);
     TimeoutStateEntry *current = g_timeout_states;
     while (current) {
         if (current->state != NULL) {
@@ -602,6 +621,8 @@ int GetTimeoutOpaqueCount(void) {
         }
         current = current->next;
     }
+    pthread_mutex_unlock(&g_timeout_states_mu);
+
     return count;
 }
 
@@ -610,23 +631,11 @@ int timeoutHandler(JSRuntime *rt, void *opaque) {
     time_t timeout = ts->timeout;
     time_t start = ts->start;
     if (timeout <= 0) {
-        TimeoutStruct *owned = takeTimeoutState(rt);
-        if (owned) {
-            free(owned);
-        } else {
-            free(ts);
-        }
         return 0;
     }
 
     time_t now = time(NULL);
     if (now - start > timeout) {
-        TimeoutStruct *owned = takeTimeoutState(rt);
-        if (owned) {
-            free(owned);
-        } else {
-            free(ts);
-        }
         return 1;
     }
 
@@ -634,22 +643,28 @@ int timeoutHandler(JSRuntime *rt, void *opaque) {
 }
 
 void SetExecuteTimeout(JSRuntime *rt, time_t timeout) {
-    clearTimeoutState(rt);
     if (timeout <= 0) {
         JS_SetInterruptHandler(rt, NULL, NULL);
+        clearTimeoutState(rt);
         return;
     }
 
     TimeoutStruct* ts = malloc(sizeof(TimeoutStruct));
     if (!ts) {
         JS_SetInterruptHandler(rt, NULL, NULL);
+        clearTimeoutState(rt);
         return;
     }
 
     ts->start = time(NULL);
     ts->timeout = timeout;
-    setTimeoutState(rt, ts);
     JS_SetInterruptHandler(rt, timeoutHandler, ts);
+
+    if (setTimeoutState(rt, ts) != 0) {
+        JS_SetInterruptHandler(rt, NULL, NULL);
+        free(ts);
+        clearTimeoutState(rt);
+    }
 }
 
 // ============================================================================

--- a/bridge.c
+++ b/bridge.c
@@ -513,6 +513,8 @@ JSValue CreateClassInstance(JSContext *ctx, JSValue constructor,
 // INTERRUPT HANDLERS
 // ============================================================================
 
+static void clearTimeoutState(JSRuntime *rt);
+
 // Simplified interrupt handler (no handlerArgs complexity)
 int interruptHandler(JSRuntime *rt, void *opaque) {
     JSRuntime *runtimePtr = (JSRuntime*)opaque;
@@ -520,11 +522,13 @@ int interruptHandler(JSRuntime *rt, void *opaque) {
 }
 
 void SetInterruptHandler(JSRuntime *rt) {
+    clearTimeoutState(rt);
     // Use rt itself as opaque parameter for Go lookup
     JS_SetInterruptHandler(rt, interruptHandler, (void*)rt);
 }
 
 void ClearInterruptHandler(JSRuntime *rt) {
+    clearTimeoutState(rt);
     JS_SetInterruptHandler(rt, NULL, NULL);
 }
 
@@ -534,18 +538,95 @@ typedef struct {
     time_t timeout;
 } TimeoutStruct;
 
+typedef struct TimeoutStateEntry {
+    JSRuntime *rt;
+    TimeoutStruct *state;
+    struct TimeoutStateEntry *next;
+} TimeoutStateEntry;
+
+static TimeoutStateEntry *g_timeout_states = NULL;
+
+static TimeoutStruct *takeTimeoutState(JSRuntime *rt) {
+    TimeoutStateEntry *prev = NULL;
+    TimeoutStateEntry *current = g_timeout_states;
+    while (current) {
+        if (current->rt == rt) {
+            TimeoutStruct *state = current->state;
+            if (prev) {
+                prev->next = current->next;
+            } else {
+                g_timeout_states = current->next;
+            }
+            free(current);
+            return state;
+        }
+        prev = current;
+        current = current->next;
+    }
+    return NULL;
+}
+
+static void setTimeoutState(JSRuntime *rt, TimeoutStruct *state) {
+    TimeoutStateEntry *current = g_timeout_states;
+    while (current) {
+        if (current->rt == rt) {
+            current->state = state;
+            return;
+        }
+        current = current->next;
+    }
+
+    TimeoutStateEntry *entry = malloc(sizeof(TimeoutStateEntry));
+    if (!entry) {
+        return;
+    }
+    entry->rt = rt;
+    entry->state = state;
+    entry->next = g_timeout_states;
+    g_timeout_states = entry;
+}
+
+static void clearTimeoutState(JSRuntime *rt) {
+    TimeoutStruct *state = takeTimeoutState(rt);
+    if (state) {
+        free(state);
+    }
+}
+
+int GetTimeoutOpaqueCount(void) {
+    int count = 0;
+    TimeoutStateEntry *current = g_timeout_states;
+    while (current) {
+        if (current->state != NULL) {
+            count++;
+        }
+        current = current->next;
+    }
+    return count;
+}
+
 int timeoutHandler(JSRuntime *rt, void *opaque) {
     TimeoutStruct* ts = (TimeoutStruct*)opaque;
     time_t timeout = ts->timeout;
     time_t start = ts->start;
     if (timeout <= 0) {
-        free(ts); // Free memory if timeout is disabled
+        TimeoutStruct *owned = takeTimeoutState(rt);
+        if (owned) {
+            free(owned);
+        } else {
+            free(ts);
+        }
         return 0;
     }
 
     time_t now = time(NULL);
     if (now - start > timeout) {
-        free(ts); // Free memory on timeout
+        TimeoutStruct *owned = takeTimeoutState(rt);
+        if (owned) {
+            free(owned);
+        } else {
+            free(ts);
+        }
         return 1;
     }
 
@@ -553,9 +634,21 @@ int timeoutHandler(JSRuntime *rt, void *opaque) {
 }
 
 void SetExecuteTimeout(JSRuntime *rt, time_t timeout) {
+    clearTimeoutState(rt);
+    if (timeout <= 0) {
+        JS_SetInterruptHandler(rt, NULL, NULL);
+        return;
+    }
+
     TimeoutStruct* ts = malloc(sizeof(TimeoutStruct));
+    if (!ts) {
+        JS_SetInterruptHandler(rt, NULL, NULL);
+        return;
+    }
+
     ts->start = time(NULL);
     ts->timeout = timeout;
+    setTimeoutState(rt, ts);
     JS_SetInterruptHandler(rt, timeoutHandler, ts);
 }
 

--- a/bridge.go
+++ b/bridge.go
@@ -250,7 +250,7 @@ func goClassConstructorProxy(ctx *C.JSContext, newTarget C.JSValue,
 	}
 
 	// Extract class ID from newTarget for instance creation
-	classID, exists := getConstructorClassID(newTarget)
+	classID, exists := getConstructorClassID(goCtx, newTarget)
 	if !exists {
 		// This should not happen in normal cases since we register constructors
 		// But provide fallback for defensive programming

--- a/bridge.h
+++ b/bridge.h
@@ -162,6 +162,7 @@ extern JSValue LoadModuleBytecode(JSContext *ctx, const uint8_t *buf, size_t buf
 extern void SetInterruptHandler(JSRuntime *rt);
 extern void ClearInterruptHandler(JSRuntime *rt);
 extern void SetExecuteTimeout(JSRuntime *rt, time_t timeout);
+extern int GetTimeoutOpaqueCount(void);
 
 // =============================================================================
 // MODULE-RELATED DECLARATIONS - NEW FOR MODULE BUILDER

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -429,9 +429,8 @@ func TestBridgeClassConstructorErrors(t *testing.T) {
 
 		ctx.Globals().Set("TestClass", constructor)
 
-		// Manually remove constructor from global registry to simulate class ID not found
-		constructorKey := jsValueToKey(constructor.ref)
-		globalConstructorRegistry.Delete(constructorKey)
+		// Manually remove constructor mapping to simulate class ID not found
+		deleteConstructorClassID(ctx, constructor.ref)
 
 		// Call constructor - triggers "Class ID not found for constructor" branch
 		result := ctx.Eval(`
@@ -1241,14 +1240,14 @@ func TestBridgeCreateClassInstanceFailures(t *testing.T) {
 
 		// Replace with invalid class ID to trigger JS_NewObjectProtoClass failure
 		constructorKey := jsValueToKey(constructor.ref)
-		globalConstructorRegistry.Store(constructorKey, uint32(999999))
+		ctx.runtime.constructorRegistry.Store(constructorKey, uint32(999999))
 
 		// This should trigger CreateClassInstance to return JS_EXCEPTION
 		result := ctx.Eval(`new TestClass()`)
 		defer result.Free()
 
 		// Restore for cleanup
-		globalConstructorRegistry.Store(constructorKey, originalClassID)
+		ctx.runtime.constructorRegistry.Store(constructorKey, originalClassID)
 
 		// Should get an error
 		if result.IsException() {

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -57,6 +57,8 @@ func TestBridgeGetRuntimeFromJSReturnNil(t *testing.T) {
 	// Test getRuntimeFromJS return nil in goInterruptHandler
 	t.Run("GetRuntimeFromJSReturnNil", func(t *testing.T) {
 		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
 
 		// Set interrupt handler
 		interruptCalled := false
@@ -64,8 +66,6 @@ func TestBridgeGetRuntimeFromJSReturnNil(t *testing.T) {
 			interruptCalled = true
 			return 1 // Request interrupt
 		})
-
-		ctx := rt.NewContext()
 
 		// Unregister runtime from mapping before executing long-running code
 		unregisterRuntime(rt.ref)

--- a/class.go
+++ b/class.go
@@ -7,16 +7,12 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"sync"
 	"unsafe"
 )
 
 // =============================================================================
-// GLOBAL CONSTRUCTOR REGISTRY FOR UNIFIED MAPPING
+// RUNTIME-SCOPED CONSTRUCTOR REGISTRY FOR UNIFIED MAPPING
 // =============================================================================
-
-// Global constructor to class ID mapping table for unified management
-var globalConstructorRegistry = sync.Map{} // constructor hash -> classID
 
 // Helper function to create a stable key from JSValue
 // For constructor functions, we use the object pointer as a unique identifier
@@ -28,18 +24,26 @@ func jsValueToKey(jsVal C.JSValue) uint64 {
 }
 
 // registerConstructorClassID stores the constructor -> classID mapping
-func registerConstructorClassID(constructor C.JSValue, classID uint32) {
-	constructorKey := jsValueToKey(constructor)
-	globalConstructorRegistry.Store(constructorKey, classID)
+func registerConstructorClassID(ctx *Context, constructor C.JSValue, classID uint32) {
+	if ctx == nil || ctx.runtime == nil {
+		return
+	}
+	ctx.runtime.registerConstructorClassID(constructor, classID)
 }
 
 // getConstructorClassID retrieves the classID for a given constructor
-func getConstructorClassID(constructor C.JSValue) (uint32, bool) {
-	constructorKey := jsValueToKey(constructor)
-	if classIDInterface, ok := globalConstructorRegistry.Load(constructorKey); ok {
-		return classIDInterface.(uint32), true
+func getConstructorClassID(ctx *Context, constructor C.JSValue) (uint32, bool) {
+	if ctx == nil || ctx.runtime == nil {
+		return 0, false
 	}
-	return 0, false
+	return ctx.runtime.getConstructorClassID(constructor)
+}
+
+func deleteConstructorClassID(ctx *Context, constructor C.JSValue) {
+	if ctx == nil || ctx.runtime == nil {
+		return
+	}
+	ctx.runtime.constructorRegistry.Delete(jsValueToKey(constructor))
 }
 
 // =============================================================================
@@ -439,7 +443,7 @@ func createClass(ctx *Context, builder *ClassBuilder) (*Value, uint32) {
 
 	// SCHEME C STEP 11: Register constructor -> classID mapping for constructor proxy access
 	// This enables constructor proxy to extract classID from newTarget
-	registerConstructorClassID(constructor, uint32(classID))
+	registerConstructorClassID(ctx, constructor, uint32(classID))
 
 	// Success: className, classDef, and classID are all managed properly
 	// - className and classDef: Go GC manages lifetime (QuickJS holds references)

--- a/class_test.go
+++ b/class_test.go
@@ -1209,7 +1209,7 @@ func TestUnifiedConstructorMapping(t *testing.T) {
 	}
 
 	// Verify both constructors are registered in the unified mapping
-	manualRetrievedID, exists := getConstructorClassID(manualConstructor.ref)
+	manualRetrievedID, exists := getConstructorClassID(ctx, manualConstructor.ref)
 	if !exists {
 		t.Errorf("Manual constructor not found in unified mapping")
 	}
@@ -1217,7 +1217,7 @@ func TestUnifiedConstructorMapping(t *testing.T) {
 		t.Errorf("Manual constructor classID mismatch: expected %d, got %d", manualClassID, manualRetrievedID)
 	}
 
-	reflectRetrievedID, exists := getConstructorClassID(reflectConstructor.ref)
+	reflectRetrievedID, exists := getConstructorClassID(ctx, reflectConstructor.ref)
 	if !exists {
 		t.Errorf("Reflection constructor not found in unified mapping")
 	}
@@ -1250,6 +1250,90 @@ func TestUnifiedConstructorMapping(t *testing.T) {
 		t.Errorf("Reflection constructor instance incorrect: got (%f, %f)",
 			result.GetIdx(2).ToFloat64(), result.GetIdx(3).ToFloat64())
 	}
+}
+
+func TestConstructorRegistryRuntimeScopedIsolation(t *testing.T) {
+	rt1 := NewRuntime()
+	ctx1 := rt1.NewContext()
+	require.NotNil(t, ctx1)
+
+	ctor1, _ := NewClassBuilder("ScopedA").
+		Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
+			return &Point{X: 1, Y: 2}, nil
+		}).
+		Build(ctx1)
+	require.False(t, ctor1.IsException())
+	ctx1.Globals().Set("ScopedA", ctor1)
+
+	rt2 := NewRuntime()
+	defer rt2.Close()
+	ctx2 := rt2.NewContext()
+	defer ctx2.Close()
+	require.NotNil(t, ctx2)
+
+	ctor2, _ := NewClassBuilder("ScopedB").
+		Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
+			return &Point{X: 3, Y: 4}, nil
+		}).
+		Build(ctx2)
+	require.False(t, ctor2.IsException())
+	ctx2.Globals().Set("ScopedB", ctor2)
+
+	rt1.Close()
+	require.NotPanics(t, func() {
+		ctx1.Close()
+	})
+
+	result := ctx2.Eval(`new ScopedB()`)
+	defer result.Free()
+	require.False(t, result.IsException())
+}
+
+func TestConstructorRegistryCorruptedEntryFailClosed(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	ctor, _ := NewClassBuilder("CorruptedRegistryClass").
+		Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
+			return &Point{X: 5, Y: 6}, nil
+		}).
+		Build(ctx)
+	require.False(t, ctor.IsException())
+	defer ctor.Free()
+
+	key := jsValueToKey(ctor.ref)
+	ctx.runtime.constructorRegistry.Store(key, "bad-entry")
+
+	_, exists := getConstructorClassID(ctx, ctor.ref)
+	require.False(t, exists)
+
+	_, stillExists := ctx.runtime.constructorRegistry.Load(key)
+	require.False(t, stillExists)
+}
+
+func TestConstructorRegistryNilContextGuards(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	ctor, _ := NewClassBuilder("NilContextRegistryClass").
+		Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
+			return &Point{X: 7, Y: 8}, nil
+		}).
+		Build(ctx)
+	require.False(t, ctor.IsException())
+	defer ctor.Free()
+
+	require.NotPanics(t, func() {
+		registerConstructorClassID(nil, ctor.ref, 123)
+		deleteConstructorClassID(nil, ctor.ref)
+	})
+
+	_, exists := getConstructorClassID(nil, ctor.ref)
+	require.False(t, exists)
 }
 
 // TestReadOnlyAndWriteOnlyAccessors tests readonly and writeonly accessor functionality

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package quickjs
 import (
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -22,6 +23,7 @@ type Context struct {
 	handleStore *handleStore //  function handle storage
 	jobQueue    chan func(*Context)
 	jobClosed   chan struct{}
+	closeOnce   sync.Once
 }
 
 const defaultJobQueueSize = 1024
@@ -156,28 +158,41 @@ func (ctx *Context) Runtime() *Runtime {
 
 // Free will free context and all associated objects.
 func (ctx *Context) Close() {
-	if ctx.jobClosed != nil {
-		select {
-		case <-ctx.jobClosed:
-		default:
-			close(ctx.jobClosed)
+	if ctx == nil {
+		return
+	}
+
+	ctx.closeOnce.Do(func() {
+		if ctx.jobClosed != nil {
+			select {
+			case <-ctx.jobClosed:
+			default:
+				close(ctx.jobClosed)
+			}
 		}
-	}
-	ctx.drainJobs()
+		ctx.drainJobs()
 
-	if ctx.globals != nil {
-		ctx.globals.Free()
-	}
+		if ctx.globals != nil {
+			ctx.globals.Free()
+		}
 
-	// Clean up all registered function handles (critical for memory management)
-	if ctx.handleStore != nil {
-		ctx.handleStore.Clear()
-	}
+		// Clean up all registered function handles (critical for memory management)
+		if ctx.handleStore != nil {
+			ctx.handleStore.Clear()
+		}
 
-	// Remove from global mapping
-	unregisterContext(ctx.ref)
+		if ctx.runtime != nil {
+			ctx.runtime.unregisterOwnedContext(ctx.ref)
+		}
 
-	C.JS_FreeContext(ctx.ref)
+		// Remove from global mapping and release C context once.
+		if ctx.ref != nil {
+			unregisterContext(ctx.ref)
+			C.JS_FreeContext(ctx.ref)
+		}
+
+		ctx.runtime = nil
+	})
 }
 
 // NewNull returns a null value.

--- a/context_test.go
+++ b/context_test.go
@@ -69,6 +69,13 @@ func TestContextBasics(t *testing.T) {
 
 }
 
+func TestContextCloseNilReceiver(t *testing.T) {
+	var ctx *Context
+	require.NotPanics(t, func() {
+		ctx.Close()
+	})
+}
+
 func TestContextEvaluation(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()

--- a/quickjs_test.go
+++ b/quickjs_test.go
@@ -2,6 +2,7 @@ package quickjs_test
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/buke/quickjs-go"
@@ -35,6 +36,9 @@ func (u *User) GetAverageScore() float64 {
 }
 
 func Example() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	// Create a new runtime
 	rt := quickjs.NewRuntime()
 	defer rt.Close()

--- a/runtime.go
+++ b/runtime.go
@@ -23,6 +23,14 @@ type interruptHandlerHolder struct {
 // It must remain nil in production.
 var runtimeNewContextHook func(rt *C.JSRuntime) *C.JSContext
 
+// runtimeInitContextHook is used in tests to force context initialization failure paths.
+// It must remain nil in production.
+var runtimeInitContextHook func(ctx *C.JSContext) C.JSValue
+
+// runtimeEvalFunctionHook is used in tests to force JS_EvalFunction failure paths.
+// It must remain nil in production.
+var runtimeEvalFunctionHook func(ctx *C.JSContext, compiled C.JSValue) C.JSValue
+
 // Runtime represents a Javascript runtime with simplified interrupt handling
 type Runtime struct {
 	mu                     sync.RWMutex
@@ -398,16 +406,10 @@ func (r *Runtime) NewContext() *Context {
     globalThis.setTimeout = setTimeout;
     globalThis.clearTimeout = clearTimeout;
     `
-	codePtr := C.CString(code)
-	defer C.free(unsafe.Pointer(codePtr))
-	filenamePtr := C.CString("init.js")
-	defer C.free(unsafe.Pointer(filenamePtr))
-
-	// Replace evaluation flags with function calls
-	evalFlags := C.int(C.GetEvalTypeModule()) | C.int(C.GetEvalFlagCompileOnly())
-	init_compile := C.JS_Eval(ctx_ref, codePtr, C.size_t(len(code)), filenamePtr, evalFlags)
-	init_run := C.js_std_await(ctx_ref, C.JS_EvalFunction(ctx_ref, init_compile))
-	C.JS_FreeValue(ctx_ref, init_run)
+	if !initializeContextGlobals(ctx_ref, code, "init.js") {
+		C.JS_FreeContext(ctx_ref)
+		return nil
+	}
 
 	// Create Context with HandleStore for function management
 	ctx := &Context{
@@ -466,6 +468,50 @@ func timeoutOpaqueCount() int {
 	return int(C.GetTimeoutOpaqueCount())
 }
 
+func initializeContextGlobals(ctx *C.JSContext, code string, filename string) bool {
+	if runtimeInitContextHook != nil {
+		initRun := runtimeInitContextHook(ctx)
+		if C.JS_IsException_Wrapper(initRun) == 1 {
+			C.JS_FreeValue(ctx, initRun)
+			return false
+		}
+		C.JS_FreeValue(ctx, initRun)
+		return true
+	}
+
+	codePtr := C.CString(code)
+	defer C.free(unsafe.Pointer(codePtr))
+	filenamePtr := C.CString(filename)
+	defer C.free(unsafe.Pointer(filenamePtr))
+
+	evalFlags := C.int(C.GetEvalTypeModule()) | C.int(C.GetEvalFlagCompileOnly())
+	initCompile := C.JS_Eval(ctx, codePtr, C.size_t(len(code)), filenamePtr, evalFlags)
+	if C.JS_IsException_Wrapper(initCompile) == 1 {
+		C.JS_FreeValue(ctx, initCompile)
+		return false
+	}
+
+	initEval := initCompile
+	if runtimeEvalFunctionHook != nil {
+		initEval = runtimeEvalFunctionHook(ctx, initCompile)
+	} else {
+		initEval = C.JS_EvalFunction(ctx, initCompile)
+	}
+	if C.JS_IsException_Wrapper(initEval) == 1 {
+		C.JS_FreeValue(ctx, initEval)
+		return false
+	}
+
+	initRun := C.js_std_await(ctx, initEval)
+	if C.JS_IsException_Wrapper(initRun) == 1 {
+		C.JS_FreeValue(ctx, initRun)
+		return false
+	}
+
+	C.JS_FreeValue(ctx, initRun)
+	return true
+}
+
 func forceRuntimeNewContextFailureForTest(enable bool) func() {
 	oldHook := runtimeNewContextHook
 	if enable {
@@ -477,5 +523,52 @@ func forceRuntimeNewContextFailureForTest(enable bool) func() {
 	}
 	return func() {
 		runtimeNewContextHook = oldHook
+	}
+}
+
+func forceRuntimeInitFailureForTest(enable bool) func() {
+	oldHook := runtimeInitContextHook
+	if enable {
+		runtimeInitContextHook = func(ctx *C.JSContext) C.JSValue {
+			msg := C.CString("forced init failure")
+			defer C.free(unsafe.Pointer(msg))
+			return C.ThrowInternalError(ctx, msg)
+		}
+	} else {
+		runtimeInitContextHook = nil
+	}
+	return func() {
+		runtimeInitContextHook = oldHook
+	}
+}
+
+func forceRuntimeInitSuccessForTest(enable bool) func() {
+	oldHook := runtimeInitContextHook
+	if enable {
+		runtimeInitContextHook = func(ctx *C.JSContext) C.JSValue {
+			return C.JS_NewUndefined()
+		}
+	} else {
+		runtimeInitContextHook = nil
+	}
+	return func() {
+		runtimeInitContextHook = oldHook
+	}
+}
+
+func forceRuntimeEvalFailureForTest(enable bool) func() {
+	oldHook := runtimeEvalFunctionHook
+	if enable {
+		runtimeEvalFunctionHook = func(ctx *C.JSContext, compiled C.JSValue) C.JSValue {
+			C.JS_FreeValue(ctx, compiled)
+			msg := C.CString("forced eval failure")
+			defer C.free(unsafe.Pointer(msg))
+			return C.ThrowInternalError(ctx, msg)
+		}
+	} else {
+		runtimeEvalFunctionHook = nil
+	}
+	return func() {
+		runtimeEvalFunctionHook = oldHook
 	}
 }

--- a/runtime.go
+++ b/runtime.go
@@ -6,7 +6,6 @@ package quickjs
 */
 import "C"
 import (
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -98,8 +97,6 @@ func WithStripInfo(strip int) Option {
 
 // NewRuntime creates a new quickjs runtime with simplified interrupt handling.
 func NewRuntime(opts ...Option) *Runtime {
-	runtime.LockOSThread() // prevent multiple quickjs runtime from being created
-
 	options := &Options{
 		timeout:      0,
 		memoryLimit:  0,
@@ -186,7 +183,6 @@ func (r *Runtime) Close() {
 		r.mu.Lock()
 		defer r.mu.Unlock()
 		if r.ref == nil {
-			runtime.UnlockOSThread()
 			return
 		}
 
@@ -207,7 +203,6 @@ func (r *Runtime) Close() {
 
 		C.JS_FreeRuntime(ref)
 		r.ref = nil
-		runtime.UnlockOSThread()
 	})
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -7,6 +7,8 @@ package quickjs
 import "C"
 import (
 	"runtime"
+	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
@@ -14,11 +16,25 @@ import (
 // Return != 0 if the JS code needs to be interrupted
 type InterruptHandler func() int
 
+type interruptHandlerHolder struct {
+	fn InterruptHandler
+}
+
+// runtimeNewContextHook is used in tests to force JS_NewContext failure paths.
+// It must remain nil in production.
+var runtimeNewContextHook func(rt *C.JSRuntime) *C.JSContext
+
 // Runtime represents a Javascript runtime with simplified interrupt handling
 type Runtime struct {
-	ref              *C.JSRuntime
-	options          *Options
-	interruptHandler InterruptHandler // Store interrupt handler directly (no cgo.Handle)
+	mu                     sync.RWMutex
+	ref                    *C.JSRuntime
+	options                *Options
+	interruptHandlerState  atomic.Pointer[interruptHandlerHolder]
+	contexts               sync.Map
+	constructorRegistry    sync.Map
+	closeOnce              sync.Once
+	closed                 atomic.Bool
+	stdHandlersInitialized bool
 }
 
 type Options struct {
@@ -101,6 +117,7 @@ func NewRuntime(opts ...Option) *Runtime {
 		ref:     C.JS_NewRuntime(),
 		options: options,
 	}
+	registerRuntime(rt.ref, rt)
 
 	// Configure runtime options
 	if rt.options.memoryLimit > 0 {
@@ -125,44 +142,86 @@ func NewRuntime(opts ...Option) *Runtime {
 		rt.SetModuleImport(rt.options.moduleImport)
 	}
 
-	// Set timeout after registration (will override interrupt handler)
+	// Set timeout after other options (will override interrupt handler)
 	if rt.options.timeout > 0 {
 		rt.SetExecuteTimeout(rt.options.timeout)
 	}
-
-	// Register runtime for interrupt handler mapping
-	registerRuntime(rt.ref, rt)
 
 	return rt
 }
 
 // RunGC will call quickjs's garbage collector.
 func (r *Runtime) RunGC() {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
 	C.JS_RunGC(r.ref)
 }
 
 // Close will free the runtime pointer with proper cleanup.
 func (r *Runtime) Close() {
-	// Step 1: Clear interrupt handler before closing
-	r.ClearInterruptHandler()
+	if r == nil {
+		return
+	}
 
-	// Step 2: Clean up global constructor registry safely
-	// Use Range + Delete to avoid potential race conditions with map replacement
-	globalConstructorRegistry.Range(func(key, value interface{}) bool {
-		globalConstructorRegistry.Delete(key)
-		return true // continue iteration
+	r.closeOnce.Do(func() {
+		r.closed.Store(true)
+
+		var contexts []*Context
+		r.contexts.Range(func(_, value interface{}) bool {
+			if ctx, ok := value.(*Context); ok {
+				contexts = append(contexts, ctx)
+			}
+			return true
+		})
+		for _, ctx := range contexts {
+			ctx.Close()
+		}
+
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if r.ref == nil {
+			runtime.UnlockOSThread()
+			return
+		}
+
+		ref := r.ref
+		r.interruptHandlerState.Store(nil)
+		C.ClearInterruptHandler(ref)
+
+		r.constructorRegistry.Range(func(key, _ interface{}) bool {
+			r.constructorRegistry.Delete(key)
+			return true
+		})
+
+		unregisterRuntime(ref)
+		if r.stdHandlersInitialized {
+			C.js_std_free_handlers(ref)
+			r.stdHandlersInitialized = false
+		}
+
+		C.JS_FreeRuntime(ref)
+		r.ref = nil
+		runtime.UnlockOSThread()
 	})
-
-	// Step 3: Unregister runtime mapping
-	unregisterRuntime(r.ref)
-
-	// Step 4: Free QuickJS runtime
-	C.JS_FreeRuntime(r.ref)
-
 }
 
 // SetCanBlock will set the runtime's can block; default is true
 func (r *Runtime) SetCanBlock(canBlock bool) {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
+
 	if canBlock {
 		C.JS_SetCanBlock(r.ref, C.int(1))
 	} else {
@@ -172,41 +231,101 @@ func (r *Runtime) SetCanBlock(canBlock bool) {
 
 // SetMemoryLimit the runtime memory limit; if not set, it will be unlimit.
 func (r *Runtime) SetMemoryLimit(limit uint64) {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
 	C.JS_SetMemoryLimit(r.ref, C.size_t(limit))
 }
 
 // SetGCThreshold the runtime's GC threshold; use -1 to disable automatic GC.
 func (r *Runtime) SetGCThreshold(threshold int64) {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
 	C.JS_SetGCThreshold(r.ref, C.size_t(threshold))
 }
 
 // SetMaxStackSize will set max runtime's stack size;
 func (r *Runtime) SetMaxStackSize(stack_size uint64) {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
 	C.JS_SetMaxStackSize(r.ref, C.size_t(stack_size))
 }
 
 // SetExecuteTimeout will set the runtime's execute timeout;
 // This will override any user interrupt handler (expected behavior)
 func (r *Runtime) SetExecuteTimeout(timeout uint64) {
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
 	C.SetExecuteTimeout(r.ref, C.time_t(timeout))
 	// Clear user interrupt handler since timeout takes precedence
-	r.interruptHandler = nil
+	r.interruptHandlerState.Store(nil)
 }
 
 // SetStripInfo sets the strip info for the runtime.
 func (r *Runtime) SetStripInfo(strip int) {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
 	C.JS_SetStripInfo(r.ref, C.int(strip))
 }
 
 // SetModuleImport sets whether the runtime supports module import.
 func (r *Runtime) SetModuleImport(moduleImport bool) {
+	if r == nil {
+		return
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
 	C.JS_SetModuleLoaderFunc2(r.ref, (*C.JSModuleNormalizeFunc)(unsafe.Pointer(nil)), (*C.JSModuleLoaderFunc2)(C.js_module_loader), (*C.JSModuleCheckSupportedImportAttributes)(C.js_module_check_attributes), unsafe.Pointer(nil))
 }
 
 // SetInterruptHandler sets a user interrupt handler using simplified approach.
 // This will override any timeout handler (expected behavior)
 func (r *Runtime) SetInterruptHandler(handler InterruptHandler) {
-	r.interruptHandler = handler
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed.Load() || r.ref == nil {
+		return
+	}
+	if handler != nil {
+		r.interruptHandlerState.Store(&interruptHandlerHolder{fn: handler})
+	} else {
+		r.interruptHandlerState.Store(nil)
+	}
 
 	if handler != nil {
 		// Simplified call - no handlerArgs complexity
@@ -218,28 +337,65 @@ func (r *Runtime) SetInterruptHandler(handler InterruptHandler) {
 
 // ClearInterruptHandler clears the user interrupt handler
 func (r *Runtime) ClearInterruptHandler() {
-	r.interruptHandler = nil
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ref == nil {
+		return
+	}
+	r.interruptHandlerState.Store(nil)
 	C.ClearInterruptHandler(r.ref)
 }
 
 // callInterruptHandler is called from C layer via runtime mapping (internal use)
 func (r *Runtime) callInterruptHandler() int {
-	if r.interruptHandler != nil {
-		return r.interruptHandler()
+	if r == nil {
+		return 0
+	}
+	holder := r.interruptHandlerState.Load()
+	if holder != nil && holder.fn != nil {
+		return holder.fn()
 	}
 	return 0 // No interrupt
 }
 
 // NewContext creates a new JavaScript context.
 func (r *Runtime) NewContext() *Context {
-	C.js_std_init_handlers(r.ref)
+	if r == nil {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed.Load() || r.ref == nil {
+		return nil
+	}
+
+	if !r.stdHandlersInitialized {
+		C.js_std_init_handlers(r.ref)
+		r.stdHandlersInitialized = true
+	}
 
 	// create a new context (heap, global object and context stack
-	ctx_ref := C.JS_NewContext(r.ref)
+	var ctx_ref *C.JSContext
+	if runtimeNewContextHook != nil {
+		ctx_ref = runtimeNewContextHook(r.ref)
+	} else {
+		ctx_ref = C.JS_NewContext(r.ref)
+	}
+	if ctx_ref == nil {
+		return nil
+	}
 
 	// import the 'std' and 'os' modules
-	C.js_init_module_std(ctx_ref, C.CString("std"))
-	C.js_init_module_os(ctx_ref, C.CString("os"))
+	stdModuleName := C.CString("std")
+	defer C.free(unsafe.Pointer(stdModuleName))
+	osModuleName := C.CString("os")
+	defer C.free(unsafe.Pointer(osModuleName))
+	C.js_init_module_std(ctx_ref, stdModuleName)
+	C.js_init_module_os(ctx_ref, osModuleName)
 
 	// import setTimeout and clearTimeout from 'os' to globalThis
 	code := `
@@ -247,10 +403,14 @@ func (r *Runtime) NewContext() *Context {
     globalThis.setTimeout = setTimeout;
     globalThis.clearTimeout = clearTimeout;
     `
+	codePtr := C.CString(code)
+	defer C.free(unsafe.Pointer(codePtr))
+	filenamePtr := C.CString("init.js")
+	defer C.free(unsafe.Pointer(filenamePtr))
 
 	// Replace evaluation flags with function calls
 	evalFlags := C.int(C.GetEvalTypeModule()) | C.int(C.GetEvalFlagCompileOnly())
-	init_compile := C.JS_Eval(ctx_ref, C.CString(code), C.size_t(len(code)), C.CString("init.js"), evalFlags)
+	init_compile := C.JS_Eval(ctx_ref, codePtr, C.size_t(len(code)), filenamePtr, evalFlags)
 	init_run := C.js_std_await(ctx_ref, C.JS_EvalFunction(ctx_ref, init_compile))
 	C.JS_FreeValue(ctx_ref, init_run)
 
@@ -264,6 +424,63 @@ func (r *Runtime) NewContext() *Context {
 
 	// Register context mapping for C callbacks
 	registerContext(ctx_ref, ctx)
+	r.registerOwnedContext(ctx)
 
 	return ctx
+}
+
+func (r *Runtime) registerOwnedContext(ctx *Context) {
+	if r == nil || ctx == nil || ctx.ref == nil {
+		return
+	}
+	r.contexts.Store(ctx.ref, ctx)
+}
+
+func (r *Runtime) unregisterOwnedContext(ctxRef *C.JSContext) {
+	if r == nil || ctxRef == nil {
+		return
+	}
+	r.contexts.Delete(ctxRef)
+}
+
+func (r *Runtime) registerConstructorClassID(constructor C.JSValue, classID uint32) {
+	if r == nil {
+		return
+	}
+	r.constructorRegistry.Store(jsValueToKey(constructor), classID)
+}
+
+func (r *Runtime) getConstructorClassID(constructor C.JSValue) (uint32, bool) {
+	if r == nil {
+		return 0, false
+	}
+
+	constructorKey := jsValueToKey(constructor)
+	if classIDInterface, ok := r.constructorRegistry.Load(constructorKey); ok {
+		classID, ok := classIDInterface.(uint32)
+		if !ok {
+			r.constructorRegistry.Delete(constructorKey)
+			return 0, false
+		}
+		return classID, true
+	}
+	return 0, false
+}
+
+func timeoutOpaqueCount() int {
+	return int(C.GetTimeoutOpaqueCount())
+}
+
+func forceRuntimeNewContextFailureForTest(enable bool) func() {
+	oldHook := runtimeNewContextHook
+	if enable {
+		runtimeNewContextHook = func(rt *C.JSRuntime) *C.JSContext {
+			return nil
+		}
+	} else {
+		runtimeNewContextHook = nil
+	}
+	return func() {
+		runtimeNewContextHook = oldHook
+	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -383,3 +383,152 @@ func TestRuntimeAdvancedOptions(t *testing.T) {
 	require.False(t, result4.IsException()) // Check for exceptions instead of error
 	require.Equal(t, "GC test", result4.ToString())
 }
+
+func TestRuntimeTimeoutOpaqueLifecycle(t *testing.T) {
+	base := timeoutOpaqueCount()
+
+	rt := NewRuntime()
+	defer rt.Close()
+
+	require.Equal(t, base, timeoutOpaqueCount())
+
+	rt.SetExecuteTimeout(5)
+	require.Equal(t, base+1, timeoutOpaqueCount())
+
+	rt.SetInterruptHandler(func() int { return 0 })
+	require.Equal(t, base, timeoutOpaqueCount())
+
+	rt.SetExecuteTimeout(5)
+	require.Equal(t, base+1, timeoutOpaqueCount())
+
+	rt.ClearInterruptHandler()
+	require.Equal(t, base, timeoutOpaqueCount())
+
+	rt.SetExecuteTimeout(5)
+	require.Equal(t, base+1, timeoutOpaqueCount())
+
+	rt.SetExecuteTimeout(0)
+	require.Equal(t, base, timeoutOpaqueCount())
+}
+
+func TestRuntimeStdHandlersLifecycle(t *testing.T) {
+	rt := NewRuntime()
+	require.False(t, rt.stdHandlersInitialized)
+
+	ctx1 := rt.NewContext()
+	require.NotNil(t, ctx1)
+	require.True(t, rt.stdHandlersInitialized)
+
+	ctx2 := rt.NewContext()
+	require.NotNil(t, ctx2)
+	require.True(t, rt.stdHandlersInitialized)
+
+	ctx1.Close()
+	ctx2.Close()
+	rt.Close()
+
+	require.False(t, rt.stdHandlersInitialized)
+	require.Equal(t, 0, timeoutOpaqueCount())
+}
+
+func TestRuntimeCloseIdempotentAndCloseOrder(t *testing.T) {
+	rt := NewRuntime()
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+
+	result := ctx.Eval(`1 + 1`)
+	require.False(t, result.IsException())
+	result.Free()
+
+	require.NotPanics(t, func() {
+		rt.Close()
+	})
+	require.NotPanics(t, func() {
+		rt.Close()
+	})
+	require.NotPanics(t, func() {
+		ctx.Close()
+	})
+
+	require.Nil(t, rt.NewContext())
+
+	require.NotPanics(t, func() {
+		rt.SetExecuteTimeout(1)
+		rt.SetInterruptHandler(func() int { return 1 })
+		rt.ClearInterruptHandler()
+		rt.SetMemoryLimit(1024)
+		rt.SetGCThreshold(2048)
+		rt.SetMaxStackSize(4096)
+		rt.SetCanBlock(true)
+		rt.SetStripInfo(1)
+		rt.SetModuleImport(true)
+		rt.RunGC()
+	})
+}
+
+func TestRuntimeNilAndZeroValueGuards(t *testing.T) {
+	var nilRT *Runtime
+	dummyRef := (Value{}).ref
+
+	require.NotPanics(t, func() {
+		nilRT.RunGC()
+		nilRT.Close()
+		nilRT.SetCanBlock(true)
+		nilRT.SetMemoryLimit(1)
+		nilRT.SetGCThreshold(1)
+		nilRT.SetMaxStackSize(1)
+		nilRT.SetExecuteTimeout(1)
+		nilRT.SetStripInfo(1)
+		nilRT.SetModuleImport(true)
+		nilRT.SetInterruptHandler(func() int { return 0 })
+		nilRT.ClearInterruptHandler()
+		require.Nil(t, nilRT.NewContext())
+		require.Equal(t, 0, nilRT.callInterruptHandler())
+		nilRT.registerOwnedContext(nil)
+		nilRT.unregisterOwnedContext(nil)
+		nilRT.registerConstructorClassID(dummyRef, 1)
+		_, _ = nilRT.getConstructorClassID(dummyRef)
+	})
+
+	zeroRT := &Runtime{}
+	require.NotPanics(t, func() {
+		zeroRT.RunGC()
+		zeroRT.SetCanBlock(true)
+		zeroRT.SetMemoryLimit(1)
+		zeroRT.SetGCThreshold(1)
+		zeroRT.SetMaxStackSize(1)
+		zeroRT.SetExecuteTimeout(1)
+		zeroRT.SetStripInfo(1)
+		zeroRT.SetModuleImport(true)
+		zeroRT.SetInterruptHandler(func() int { return 1 })
+		zeroRT.ClearInterruptHandler()
+		zeroRT.registerOwnedContext(nil)
+		zeroRT.unregisterOwnedContext(nil)
+		require.Nil(t, zeroRT.NewContext())
+		zeroRT.Close()
+		zeroRT.Close()
+	})
+}
+
+func TestRuntimeNewContextFailureHook(t *testing.T) {
+	restore := forceRuntimeNewContextFailureForTest(true)
+	defer restore()
+
+	rt := NewRuntime()
+	defer rt.Close()
+
+	ctx := rt.NewContext()
+	require.Nil(t, ctx)
+}
+
+func TestRuntimeNewContextFailureHookDisable(t *testing.T) {
+	restore := forceRuntimeNewContextFailureForTest(false)
+	defer restore()
+
+	rt := NewRuntime()
+	defer rt.Close()
+
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+	ctx.Close()
+}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -78,10 +78,11 @@ func TestRuntimeLimitsAndErrors(t *testing.T) {
 	})
 
 	t.Run("StackOverflow", func(t *testing.T) {
-		rt := NewRuntime(WithMaxStackSize(8192))
+		rt := NewRuntime(WithMaxStackSize(65534))
 		defer rt.Close()
 
 		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
 		defer ctx.Close()
 
 		result := ctx.Eval(`
@@ -635,4 +636,65 @@ func TestRuntimeNewContextFailureHookDisable(t *testing.T) {
 	ctx := rt.NewContext()
 	require.NotNil(t, ctx)
 	ctx.Close()
+}
+
+func TestRuntimeNewContextInitFailureHook(t *testing.T) {
+	restore := forceRuntimeInitFailureForTest(true)
+	defer restore()
+
+	rt := NewRuntime()
+	defer rt.Close()
+
+	ctx := rt.NewContext()
+	require.Nil(t, ctx)
+
+	// A failed initialization should not poison the runtime for future contexts.
+	restoreInit := forceRuntimeInitFailureForTest(false)
+	defer restoreInit()
+
+	ctx = rt.NewContext()
+	require.NotNil(t, ctx)
+	ctx.Close()
+}
+
+func TestInitializeContextGlobalsFailurePaths(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+	defer ctx.Close()
+
+	t.Run("CompileException", func(t *testing.T) {
+		require.False(t, initializeContextGlobals(ctx.ref, "function {", "compile-fail.js"))
+	})
+
+	t.Run("EvalException", func(t *testing.T) {
+		restore := forceRuntimeEvalFailureForTest(true)
+		defer restore()
+
+		require.False(t, initializeContextGlobals(ctx.ref, "globalThis.__evalProbe = 1", "eval-fail.js"))
+	})
+
+	t.Run("AwaitException", func(t *testing.T) {
+		require.False(t, initializeContextGlobals(ctx.ref, "await Promise.reject(new Error('await fail'))", "await-fail.js"))
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		require.True(t, initializeContextGlobals(ctx.ref, "globalThis.__initProbe = 1", "success.js"))
+	})
+
+	t.Run("HookSuccess", func(t *testing.T) {
+		restore := forceRuntimeInitSuccessForTest(true)
+		defer restore()
+
+		require.True(t, initializeContextGlobals(ctx.ref, "", "hook-success.js"))
+	})
+
+	t.Run("HookSuccessDisable", func(t *testing.T) {
+		restore := forceRuntimeInitSuccessForTest(false)
+		defer restore()
+
+		require.True(t, initializeContextGlobals(ctx.ref, "globalThis.__initProbeDisabled = 1", "hook-success-disable.js"))
+	})
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -395,6 +395,10 @@ func TestRuntimeTimeoutOpaqueLifecycle(t *testing.T) {
 	rt.SetExecuteTimeout(5)
 	require.Equal(t, base+1, timeoutOpaqueCount())
 
+	// Replacing timeout should not accumulate opaque states.
+	rt.SetExecuteTimeout(10)
+	require.Equal(t, base+1, timeoutOpaqueCount())
+
 	rt.SetInterruptHandler(func() int { return 0 })
 	require.Equal(t, base, timeoutOpaqueCount())
 
@@ -409,6 +413,106 @@ func TestRuntimeTimeoutOpaqueLifecycle(t *testing.T) {
 
 	rt.SetExecuteTimeout(0)
 	require.Equal(t, base, timeoutOpaqueCount())
+}
+
+func TestRuntimeTimeoutOpaqueNotFreedInHandler(t *testing.T) {
+	base := timeoutOpaqueCount()
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	rt.SetExecuteTimeout(1)
+	require.Equal(t, base+1, timeoutOpaqueCount())
+
+	result := ctx.Eval(`while(true){}`)
+	defer result.Free()
+	require.True(t, result.IsException())
+
+	err := ctx.Exception()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "interrupted")
+
+	// timeoutHandler should not free opaque state; cleanup happens on clear/replace.
+	require.Equal(t, base+1, timeoutOpaqueCount())
+
+	rt.ClearInterruptHandler()
+	require.Equal(t, base, timeoutOpaqueCount())
+}
+
+func TestRuntimeTimeoutOpaqueConcurrentLifecycle(t *testing.T) {
+	base := timeoutOpaqueCount()
+
+	const workers = 4
+	const loops = 50
+
+	var wg sync.WaitGroup
+	errCh := make(chan string, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			rt := NewRuntime()
+			ctx := rt.NewContext()
+			if ctx == nil {
+				errCh <- "NewContext returned nil"
+				rt.Close()
+				return
+			}
+
+			for j := 0; j < loops; j++ {
+				rt.SetExecuteTimeout(1)
+				rt.SetExecuteTimeout(2)
+				rt.ClearInterruptHandler()
+			}
+
+			ctx.Close()
+			rt.Close()
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for errMsg := range errCh {
+		t.Error(errMsg)
+	}
+
+	require.Equal(t, base, timeoutOpaqueCount())
+}
+
+func TestRuntimeCrossGoroutineLifecycleWithoutInternalThreadBinding(t *testing.T) {
+	created := make(chan *Runtime, 1)
+
+	go func() {
+		rt := NewRuntime()
+		created <- rt
+	}()
+
+	rt := <-created
+	require.NotNil(t, rt)
+
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+
+	result := ctx.Eval(`1 + 2`)
+	require.NotNil(t, result)
+	require.False(t, result.IsException())
+	require.EqualValues(t, 3, result.ToInt32())
+	result.Free()
+
+	closed := make(chan struct{})
+	go func() {
+		ctx.Close()
+		rt.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cross-goroutine close blocked")
+	}
 }
 
 func TestRuntimeStdHandlersLifecycle(t *testing.T) {

--- a/value.go
+++ b/value.go
@@ -846,7 +846,7 @@ func (v *Value) resolveClassIDFromInheritance() (uint32, bool) {
 		parent := parents.GetIdx(int64(i))
 		defer parent.Free()
 
-		if classID, exists := getConstructorClassID(parent.ref); exists {
+		if classID, exists := getConstructorClassID(v.ctx, parent.ref); exists {
 			return classID, true
 		}
 	}


### PR DESCRIPTION
- prevent timeout interrupt opaque leaks when switching handlers

- scope constructor-class registry to runtime instead of global map

- pair std handler init/free and release C strings in NewContext

- make Runtime/Context close idempotent and robust to close ordering

- add regression tests and maintain full race-safe coverage