### PR TITLE
feat: harden lifecycle boundary contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ The runtime sources under deps/quickjs are no longer updated via git submodule. 
 - Runtime and Context objects have their own cleanup methods (`Close()`). Close them once you are done using them.
 - Use `runtime.SetFinalizer()` cautiously as it may interfere with QuickJS's GC.
 
+### Lifecycle and Boundary Contracts
+- After `Context.Close()`, boundary queries are fail-closed: `Runtime()` returns `nil`, `HasException()` returns `false`, `Exception()` returns `nil`, `Loop()` becomes a no-op, and `Schedule()` returns `false`.
+- `Value.Free()` is fail-closed when its context pointer is no longer valid, avoiding unsafe cgo calls after close.
+- Bridge mapping and handle-store reads are fail-closed under corrupted entries (wrong types), preventing panic-based crashes.
+- Go callbacks returning `nil` from function/method/getter/setter proxies are normalized to JavaScript `undefined`.
+- Module exports are validated during module initialization: export values must be non-`nil`, context-live, and belong to the initializing context.
+
 ### Performance Tips
 - QuickJS is not thread-safe. For concurrency or isolation, use a thread pool pattern with pre-initialized runtimes, or manage separate Runtime/Context instances for different tasks or users.
 - Thread affinity is the caller's responsibility. This library no longer calls `runtime.LockOSThread()` / `runtime.UnlockOSThread()` internally.

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -55,6 +55,13 @@ deps/quickjs 中的运行时源码不再通过 git submodule 更新，而是按 
 - Runtime 和 Context 对象有自己的清理方法 (`Close()`)。使用完毕后立即关闭它们。
 - 谨慎使用 `runtime.SetFinalizer()`，因为它可能会干扰 QuickJS 的 GC。
 
+### 生命周期与边界契约
+- 在 `Context.Close()` 之后，边界查询采用 fail-closed 语义：`Runtime()` 返回 `nil`，`HasException()` 返回 `false`，`Exception()` 返回 `nil`，`Loop()` 变为 no-op，`Schedule()` 返回 `false`。
+- 当 `Value` 的上下文引用已失效时，`Value.Free()` 会 fail-closed，避免关闭后的不安全 cgo 调用。
+- bridge 映射和 handleStore 在遇到损坏条目（错误类型）时采用 fail-closed，避免 panic 级崩溃。
+- Go 回调在 function/method/getter/setter 代理里返回 `nil` 时，会统一映射为 JavaScript `undefined`。
+- 模块初始化阶段会校验导出值：导出值必须非 `nil`、上下文可用且属于当前初始化上下文。
+
 ### 性能建议
 - QuickJS 不是线程安全的。如需并发或隔离，建议使用线程池模式预初始化运行时，或为不同任务/用户管理独立的 Runtime/Context 实例。
 - 线程归属由调用方自己负责。当前库不再在内部偷偷调用 `runtime.LockOSThread()` / `runtime.UnlockOSThread()`。

--- a/bridge.go
+++ b/bridge.go
@@ -37,7 +37,15 @@ func unregisterContext(cCtx *C.JSContext) {
 // getContextFromJS gets Go Context from C JSContext (internal use)
 func getContextFromJS(cCtx *C.JSContext) *Context {
 	if value, ok := contextMapping.Load(cCtx); ok {
-		return value.(*Context)
+		ctx, ok := value.(*Context)
+		if !ok {
+			contextMapping.Delete(cCtx)
+			return nil
+		}
+		if !ctx.hasValidRef() {
+			return nil
+		}
+		return ctx
 	}
 	return nil
 }
@@ -55,7 +63,15 @@ func unregisterRuntime(cRt *C.JSRuntime) {
 // getRuntimeFromJS gets Go Runtime from C JSRuntime (internal use)
 func getRuntimeFromJS(cRt *C.JSRuntime) *Runtime {
 	if value, ok := runtimeMapping.Load(cRt); ok {
-		return value.(*Runtime)
+		rt, ok := value.(*Runtime)
+		if !ok {
+			runtimeMapping.Delete(cRt)
+			return nil
+		}
+		if !rt.isAlive() {
+			return nil
+		}
+		return rt
 	}
 	return nil
 }
@@ -162,7 +178,10 @@ func getContextAndModuleBuilder(ctx *C.JSContext, m *C.JSModuleDef) (*Context, *
 	}
 
 	// Type assertion to ModuleBuilder
-	builder, _ := builderInterface.(*ModuleBuilder)
+	builder, ok := builderInterface.(*ModuleBuilder)
+	if !ok || builder == nil {
+		return nil, nil, fmt.Errorf("Failed to get context and ModuleBuilder: invalid module builder handle")
+	}
 
 	return goCtx, builder, nil
 }
@@ -221,6 +240,9 @@ func goFunctionProxy(ctx *C.JSContext, thisVal C.JSValueConst,
 	args := convertCArgsToGoValues(argc, (*C.JSValue)(argv), goCtx)
 	thisValue := &Value{ctx: goCtx, ref: thisVal}
 	result := goFn(goCtx, thisValue, args)
+	if result == nil {
+		return C.JS_NewUndefined()
+	}
 	return result.ref
 }
 
@@ -323,6 +345,10 @@ func goClassConstructorProxy(ctx *C.JSContext, newTarget C.JSValue,
 
 	// SCHEME C STEP 4: Associate Go object with instance if constructor returned non-nil object
 	if goObj != nil {
+		if goCtx.handleStore == nil {
+			C.JS_FreeValue(ctx, instance)
+			return throwProxyError(ctx, proxyError{"InternalError", "Handle store not available"})
+		}
 		handleID := goCtx.handleStore.Store(goObj)
 		C.JS_SetOpaque(instance, C.IntToOpaque(C.int32_t(handleID)))
 	}
@@ -354,6 +380,9 @@ func goClassMethodProxy(ctx *C.JSContext, thisVal C.JSValue,
 	thisValue := &Value{ctx: goCtx, ref: thisVal}
 	args := convertCArgsToGoValues(argc, argv, goCtx)
 	result := method(goCtx, thisValue, args)
+	if result == nil {
+		return C.JS_NewUndefined()
+	}
 	return result.ref
 }
 
@@ -379,6 +408,9 @@ func goClassGetterProxy(ctx *C.JSContext, thisVal C.JSValue, magic C.int) C.JSVa
 	// Call getter with this value only - MODIFIED: now uses pointer conversion
 	thisValue := &Value{ctx: goCtx, ref: thisVal}
 	result := getter(goCtx, thisValue)
+	if result == nil {
+		return C.JS_NewUndefined()
+	}
 	return result.ref
 }
 
@@ -406,6 +438,9 @@ func goClassSetterProxy(ctx *C.JSContext, thisVal C.JSValue,
 	thisValue := &Value{ctx: goCtx, ref: thisVal}
 	setValue := &Value{ctx: goCtx, ref: val}
 	result := setter(goCtx, thisValue, setValue)
+	if result == nil {
+		return C.JS_NewUndefined()
+	}
 	return result.ref
 }
 
@@ -434,7 +469,10 @@ func goClassFinalizerProxy(rt *C.JSRuntime, val C.JSValue) {
 	// Since finalizer is called at runtime level, we iterate through contexts
 	var targetCtx *Context
 	contextMapping.Range(func(key, value interface{}) bool {
-		ctx := value.(*Context)
+		ctx, ok := value.(*Context)
+		if !ok || ctx == nil || ctx.runtime == nil || ctx.handleStore == nil || !ctx.hasValidRef() {
+			return true
+		}
 		if ctx.runtime.ref == rt {
 			// Check if this context has the handle
 			if _, exists := ctx.handleStore.Load(handleID); exists {
@@ -487,6 +525,10 @@ func goModuleInitProxy(ctx *C.JSContext, m *C.JSModuleDef) C.int {
 
 	// Step 2: Set all export values using JS_SetModuleExport
 	for _, export := range builder.exports {
+		if export.Value == nil || !export.Value.hasValidContext() || export.Value.ctx != goCtx {
+			return throwModuleError(ctx, fmt.Errorf("invalid module export value: %s", export.Name))
+		}
+
 		exportName := C.CString(export.Name)
 		// JS_SetModuleExport takes ownership of the JSValue (it will free it on failure).
 		// To prevent Go-side double free (issue #688), invalidate the Go Value after

--- a/bridge.go
+++ b/bridge.go
@@ -174,13 +174,13 @@ func getContextAndModuleBuilder(ctx *C.JSContext, m *C.JSModuleDef) (*Context, *
 
 	goCtx, builderInterface, err := getContextAndObject(ctx, C.int(builderID), errFunctionNotFound)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to get context and ModuleBuilder: %v", err.message)
+		return nil, nil, fmt.Errorf("failed to get context and module builder: %v", err.message)
 	}
 
 	// Type assertion to ModuleBuilder
 	builder, ok := builderInterface.(*ModuleBuilder)
 	if !ok || builder == nil {
-		return nil, nil, fmt.Errorf("Failed to get context and ModuleBuilder: invalid module builder handle")
+		return nil, nil, fmt.Errorf("failed to get context and module builder: invalid module builder handle")
 	}
 
 	return goCtx, builder, nil

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -4,10 +4,21 @@ import (
 	"fmt"
 	"runtime"
 	"runtime/cgo"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+type bridgeFinalizerProbe struct {
+	mark *atomic.Bool
+}
+
+func (p *bridgeFinalizerProbe) Finalize() {
+	if p != nil && p.mark != nil {
+		p.mark.Store(true)
+	}
+}
 
 func TestBridgeGetContextFromJSReturnNil(t *testing.T) {
 	// Test getContextFromJS return nil
@@ -100,6 +111,239 @@ func TestBridgeGetRuntimeFromJSReturnNil(t *testing.T) {
 		rt.Close()
 
 		t.Log("Successfully triggered getRuntimeFromJS return nil branch")
+	})
+}
+
+func TestBridgeMappingCorruptionFailClosed(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	require.NotNil(t, getContextFromJS(ctx.ref))
+	require.NotNil(t, getRuntimeFromJS(rt.ref))
+
+	contextMapping.Store(ctx.ref, "corrupted-context")
+	require.Nil(t, getContextFromJS(ctx.ref))
+
+	runtimeMapping.Store(rt.ref, "corrupted-runtime")
+	require.Nil(t, getRuntimeFromJS(rt.ref))
+	require.NotPanics(t, func() {
+		_ = goInterruptHandler(rt.ref)
+	})
+
+	registerContext(ctx.ref, ctx)
+	registerRuntime(rt.ref, rt)
+
+	fn := ctx.NewFunction(func(ctx *Context, this *Value, args []*Value) *Value {
+		return ctx.NewString("ok")
+	})
+	ctx.Globals().Set("__bridge_boundary_fn", fn)
+
+	result := ctx.Eval(`
+		try {
+			__bridge_boundary_fn();
+			"ok";
+		} catch (e) {
+			String(e);
+		}
+	`)
+	defer result.Free()
+	require.False(t, result.IsException())
+	require.Equal(t, "ok", result.ToString())
+}
+
+func TestBridgeMappingClosedTargetsFailClosed(t *testing.T) {
+	rt := NewRuntime()
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+
+	ctxRef := ctx.ref
+	rtRef := rt.ref
+
+	ctx.Close()
+	contextMapping.Store(ctxRef, ctx)
+	require.Nil(t, getContextFromJS(ctxRef))
+
+	rt.Close()
+	runtimeMapping.Store(rtRef, rt)
+	require.Nil(t, getRuntimeFromJS(rtRef))
+}
+
+func TestBridgeNilCallbackResultsNormalizeToUndefined(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	ctx.Globals().Set("nilFn", ctx.NewFunction(func(ctx *Context, this *Value, args []*Value) *Value {
+		return nil
+	}))
+
+	fnType := ctx.Eval(`typeof nilFn()`)
+	defer fnType.Free()
+	require.False(t, fnType.IsException())
+	require.Equal(t, "undefined", fnType.ToString())
+
+	constructor, _ := NewClassBuilder("NilBridgeClass").
+		Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
+			return map[string]int{"ok": 1}, nil
+		}).
+		Method("m", func(ctx *Context, this *Value, args []*Value) *Value {
+			return nil
+		}).
+		Accessor("a", func(ctx *Context, this *Value) *Value {
+			return nil
+		}, func(ctx *Context, this *Value, val *Value) *Value {
+			return nil
+		}).
+		Build(ctx)
+	require.False(t, constructor.IsException())
+
+	ctx.Globals().Set("NilBridgeClass", constructor)
+
+	result := ctx.Eval(`
+		(() => {
+			const o = new NilBridgeClass();
+			const m = o.m();
+			const g = o.a;
+			o.a = 123;
+			return [m === undefined, g === undefined].join(',');
+		})()
+	`)
+	defer result.Free()
+	require.False(t, result.IsException())
+	require.Equal(t, "true,true", result.ToString())
+}
+
+func TestBridgeModuleInitFailClosedInvalidExportAndBuilderHandle(t *testing.T) {
+	rt := NewRuntime(WithModuleImport(true))
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	t.Run("InvalidExportValue", func(t *testing.T) {
+		mb := NewModuleBuilder("invalid-export-module").
+			Export("bad", nil)
+		require.NoError(t, mb.Build(ctx))
+
+		result := ctx.Eval(`import('invalid-export-module')`, EvalAwait(true))
+		defer result.Free()
+		require.True(t, result.IsException())
+		err := ctx.Exception()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid module export value")
+	})
+
+	t.Run("InvalidModuleBuilderHandle", func(t *testing.T) {
+		mb := NewModuleBuilder("invalid-builder-module").
+			Export("ok", ctx.NewString("value"))
+		require.NoError(t, mb.Build(ctx))
+
+		var builderID int32
+		var originalHandle cgo.Handle
+		ctx.handleStore.handles.Range(func(key, value interface{}) bool {
+			id, ok := key.(int32)
+			if !ok {
+				return true
+			}
+			h, ok := value.(cgo.Handle)
+			if !ok {
+				return true
+			}
+			stored, ok := h.Value().(*ModuleBuilder)
+			if ok && stored != nil && stored.name == "invalid-builder-module" {
+				builderID = id
+				originalHandle = h
+				return false
+			}
+			return true
+		})
+		require.Greater(t, builderID, int32(0))
+
+		tempHandle := cgo.NewHandle("not-a-module-builder")
+		ctx.handleStore.handles.Store(builderID, tempHandle)
+		defer func() {
+			ctx.handleStore.handles.Store(builderID, originalHandle)
+			tempHandle.Delete()
+		}()
+
+		result := ctx.Eval(`import('invalid-builder-module')`, EvalAwait(true))
+		defer result.Free()
+		require.True(t, result.IsException())
+		err := ctx.Exception()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid module builder handle")
+	})
+}
+
+func TestBridgeClassConstructorHandleStoreUnavailable(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	backupStore := ctx.handleStore
+
+	constructor, _ := NewClassBuilder("HandleStoreUnavailableClass").
+		Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
+			ctx.handleStore = nil
+			return map[string]int{"x": 1}, nil
+		}).
+		Build(ctx)
+	require.False(t, constructor.IsException())
+
+	ctx.Globals().Set("HandleStoreUnavailableClass", constructor)
+
+	result := ctx.Eval(`new HandleStoreUnavailableClass()`)
+	ctx.handleStore = backupStore
+
+	defer result.Free()
+	require.True(t, result.IsException())
+	err := ctx.Exception()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Handle store not available")
+}
+
+func TestBridgeClassFinalizerProxyContracts(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	var finalized atomic.Bool
+
+	constructor, _ := NewClassBuilder("FinalizerProbeClass").
+		Constructor(func(ctx *Context, instance *Value, args []*Value) (interface{}, error) {
+			return &bridgeFinalizerProbe{mark: &finalized}, nil
+		}).
+		Build(ctx)
+	require.False(t, constructor.IsException())
+	ctx.Globals().Set("FinalizerProbeClass", constructor)
+
+	instance := ctx.Eval(`new FinalizerProbeClass()`)
+	defer instance.Free()
+	require.False(t, instance.IsException())
+
+	ctxRef := ctx.ref
+	unregisterContext(ctxRef)
+	contextMapping.Store(ctxRef, "corrupted-finalizer-mapping")
+	require.NotPanics(t, func() {
+		goClassFinalizerProxy(rt.ref, instance.ref)
+	})
+	registerContext(ctxRef, ctx)
+
+	rt2 := NewRuntime()
+	defer rt2.Close()
+	goClassFinalizerProxy(rt2.ref, instance.ref)
+	require.False(t, finalized.Load())
+
+	goClassFinalizerProxy(rt.ref, instance.ref)
+	require.True(t, finalized.Load())
+
+	// Second finalizer call should be safely ignored after handle cleanup.
+	require.NotPanics(t, func() {
+		goClassFinalizerProxy(rt.ref, instance.ref)
 	})
 }
 

--- a/context.go
+++ b/context.go
@@ -28,6 +28,22 @@ type Context struct {
 	closeOnce   sync.Once
 }
 
+// hasValidRef reports whether the context still has a valid native handle.
+func (ctx *Context) hasValidRef() bool {
+	return ctx != nil && ctx.ref != nil
+}
+
+// isAlive reports whether the context can safely reach QuickJS.
+func (ctx *Context) isAlive() bool {
+	if ctx == nil || ctx.ref == nil {
+		return false
+	}
+	if ctx.runtime == nil {
+		return false
+	}
+	return ctx.runtime.isAlive()
+}
+
 const defaultJobQueueSize = 1024
 
 // awaitPollInterval is the duration the Await loop sleeps when no JS or Go
@@ -122,7 +138,7 @@ func (ctx *Context) drainJobs() {
 }
 
 func (ctx *Context) duplicateValue(val *Value) *Value {
-	if val == nil || val.ctx == nil {
+	if !ctx.hasValidRef() || !val.hasValidContext() || val.ctx != ctx {
 		return nil
 	}
 	return &Value{ctx: ctx, ref: C.JS_DupValue(ctx.ref, val.ref)}
@@ -177,6 +193,9 @@ func (ctx *Context) wrapPromiseCallback(fn *Value) (func(*Value), func()) {
 
 // Runtime returns the runtime of the context.
 func (ctx *Context) Runtime() *Runtime {
+	if ctx == nil {
+		return nil
+	}
 	return ctx.runtime
 }
 
@@ -215,6 +234,11 @@ func (ctx *Context) Close() {
 			C.JS_FreeContext(ctx.ref)
 		}
 
+		ctx.ref = nil
+		ctx.globals = nil
+		ctx.handleStore = nil
+		ctx.jobQueue = nil
+		ctx.jobClosed = nil
 		ctx.runtime = nil
 	})
 }
@@ -677,6 +701,9 @@ func (ctx *Context) AsyncFunction(asyncFn func(ctx *Context, this *Value, promis
 
 // getFunction gets function from HandleStore (internal use)
 func (ctx *Context) loadFunctionFromHandleID(id int32) interface{} {
+	if ctx == nil || ctx.handleStore == nil || id <= 0 {
+		return nil
+	}
 	fn, _ := ctx.handleStore.Load(id)
 	return fn
 }
@@ -1041,12 +1068,18 @@ func (ctx *Context) ThrowInternalError(format string, args ...interface{}) *Valu
 
 // HasException checks if the context has an exception set.
 func (ctx *Context) HasException() bool {
+	if !ctx.hasValidRef() {
+		return false
+	}
 	// Check if the context has an exception set
 	return bool(C.JS_HasException(ctx.ref))
 }
 
 // Exception returns a context's exception value.
 func (ctx *Context) Exception() error {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	val := &Value{ctx: ctx, ref: C.JS_GetException(ctx.ref)}
 	defer val.Free()
 	return val.Error()
@@ -1054,6 +1087,9 @@ func (ctx *Context) Exception() error {
 
 // Loop runs the context's event loop.
 func (ctx *Context) Loop() {
+	if !ctx.hasValidRef() {
+		return
+	}
 	ctx.ProcessJobs()
 	C.js_std_loop(ctx.ref)
 	ctx.ProcessJobs()

--- a/context_test.go
+++ b/context_test.go
@@ -76,6 +76,82 @@ func TestContextCloseNilReceiver(t *testing.T) {
 	})
 }
 
+func TestContextPostCloseContracts(t *testing.T) {
+	rt := NewRuntime()
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+
+	v := ctx.NewString("post-close-free")
+	require.NotNil(t, v)
+
+	ctx.Close()
+
+	require.Nil(t, ctx.Runtime())
+	require.False(t, ctx.HasException())
+	require.Nil(t, ctx.Exception())
+	require.False(t, ctx.Schedule(func(*Context) {}))
+	require.NotPanics(t, func() {
+		ctx.Loop()
+	})
+	require.NotPanics(t, func() {
+		v.Free()
+	})
+
+	rt.Close()
+}
+
+func TestContextInternalStateHelpers(t *testing.T) {
+	var nilCtx *Context
+	require.Nil(t, nilCtx.Runtime())
+	require.False(t, nilCtx.isAlive())
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+
+	require.True(t, ctx.isAlive())
+
+	fn := ctx.NewFunction(func(ctx *Context, this *Value, args []*Value) *Value {
+		return ctx.NewUndefined()
+	})
+
+	var handleID int32
+	ctx.handleStore.handles.Range(func(key, _ interface{}) bool {
+		handleID = key.(int32)
+		return false
+	})
+	require.Greater(t, handleID, int32(0))
+	require.NotNil(t, ctx.loadFunctionFromHandleID(handleID))
+
+	require.Nil(t, ctx.loadFunctionFromHandleID(0))
+	require.Nil(t, ctx.loadFunctionFromHandleID(-1))
+
+	empty := &Context{}
+	require.Nil(t, empty.loadFunctionFromHandleID(handleID))
+
+	fn.Free()
+	ctx.Close()
+	require.False(t, ctx.isAlive())
+}
+
+func TestContextIsAliveEdgeCases(t *testing.T) {
+	var nilCtx *Context
+	require.False(t, nilCtx.isAlive())
+
+	refOnly := &Context{ref: nil}
+	require.False(t, refOnly.isAlive())
+
+	rt := NewRuntime()
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+
+	orphan := &Context{ref: ctx.ref}
+	require.False(t, orphan.isAlive())
+
+	ctx.Close()
+	rt.Close()
+}
+
 func TestContextEvaluation(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()

--- a/handle.go
+++ b/handle.go
@@ -27,6 +27,10 @@ func newHandleStoreWithStartID(startID int32) *handleStore {
 
 // Store stores a value and returns int32 ID (safe for JS magic parameter)
 func (hs *handleStore) Store(value interface{}) int32 {
+	if hs == nil {
+		return 0
+	}
+
 	id := hs.nextID.Add(1)
 
 	// check int32 overflow to prevent magic parameter issues
@@ -41,8 +45,16 @@ func (hs *handleStore) Store(value interface{}) int32 {
 
 // Load loads value by ID
 func (hs *handleStore) Load(id int32) (interface{}, bool) {
+	if hs == nil || id <= 0 {
+		return nil, false
+	}
+
 	if value, ok := hs.handles.Load(id); ok {
-		handle := value.(cgo.Handle)
+		handle, ok := value.(cgo.Handle)
+		if !ok {
+			hs.handles.Delete(id)
+			return nil, false
+		}
 		return handle.Value(), true
 	}
 	return nil, false
@@ -50,8 +62,15 @@ func (hs *handleStore) Load(id int32) (interface{}, bool) {
 
 // Delete deletes handle by ID and properly releases cgo.Handle
 func (hs *handleStore) Delete(id int32) bool {
+	if hs == nil || id <= 0 {
+		return false
+	}
+
 	if value, ok := hs.handles.LoadAndDelete(id); ok {
-		handle := value.(cgo.Handle)
+		handle, ok := value.(cgo.Handle)
+		if !ok {
+			return false
+		}
 		handle.Delete() // critical: release cgo.Handle to prevent memory leak
 		return true
 	}
@@ -60,9 +79,15 @@ func (hs *handleStore) Delete(id int32) bool {
 
 // Clear clears all handles (called on Context.Close)
 func (hs *handleStore) Clear() {
+	if hs == nil {
+		return
+	}
+
 	hs.handles.Range(func(key, value interface{}) bool {
-		handle := value.(cgo.Handle)
-		handle.Delete() // ensure all cgo.Handle are properly released
+		handle, ok := value.(cgo.Handle)
+		if ok {
+			handle.Delete() // ensure all cgo.Handle are properly released
+		}
 		hs.handles.Delete(key)
 		return true
 	})
@@ -70,6 +95,10 @@ func (hs *handleStore) Clear() {
 
 // Count returns number of stored handles (for debugging)
 func (hs *handleStore) Count() int {
+	if hs == nil {
+		return 0
+	}
+
 	count := 0
 	hs.handles.Range(func(_, _ interface{}) bool {
 		count++

--- a/handle_test.go
+++ b/handle_test.go
@@ -146,6 +146,36 @@ func TestHandleStore_EdgeCases(t *testing.T) {
 	})
 }
 
+func TestHandleStore_FailClosedOnCorruptedEntries(t *testing.T) {
+	hs := newHandleStore()
+	require.NotNil(t, hs)
+
+	hs.handles.Store(int32(1001), "corrupted")
+	loaded, ok := hs.Load(1001)
+	require.False(t, ok)
+	require.Nil(t, loaded)
+
+	hs.handles.Store(int32(1002), "corrupted")
+	require.False(t, hs.Delete(1002))
+
+	hs.handles.Store(int32(1003), "corrupted")
+	require.NotPanics(t, func() {
+		hs.Clear()
+	})
+	require.Equal(t, 0, hs.Count())
+
+	var nilStore *handleStore
+	require.EqualValues(t, 0, nilStore.Store("ignored"))
+	loaded, ok = nilStore.Load(1)
+	require.False(t, ok)
+	require.Nil(t, loaded)
+	require.False(t, nilStore.Delete(1))
+	require.NotPanics(t, func() {
+		nilStore.Clear()
+	})
+	require.Equal(t, 0, nilStore.Count())
+}
+
 func TestHandleStore_CustomStartID(t *testing.T) {
 	t.Run("StartFromZero", func(t *testing.T) {
 		hs := newHandleStoreWithStartID(0)

--- a/runtime.go
+++ b/runtime.go
@@ -45,6 +45,12 @@ type Runtime struct {
 	stdHandlersInitialized bool
 }
 
+// isAlive reports whether the runtime still has a valid native handle and
+// has not started closing.
+func (r *Runtime) isAlive() bool {
+	return r != nil && r.ref != nil && !r.closed.Load()
+}
+
 type Options struct {
 	timeout      uint64
 	memoryLimit  uint64

--- a/value.go
+++ b/value.go
@@ -20,12 +20,23 @@ type Value struct {
 	ref C.JSValue
 }
 
+// hasValidContext reports whether a Value still has a usable context pointer.
+func (v *Value) hasValidContext() bool {
+	return v != nil && v.ctx != nil && v.ctx.ref != nil
+}
+
+// sameContext reports whether two values belong to the same live context.
+func sameContext(a *Value, b *Value) bool {
+	return a != nil && b != nil && a.ctx != nil && b.ctx != nil && a.ctx == b.ctx && a.ctx.ref != nil && b.ctx.ref != nil
+}
+
 // Free the value.
 func (v *Value) Free() {
-	if v.ctx == nil || bool(C.JS_IsUndefined(v.ref)) {
+	if !v.hasValidContext() || bool(C.JS_IsUndefined(v.ref)) {
 		return // No context or undefined value, nothing to free
 	}
 	C.JS_FreeValue(v.ctx.ref, v.ref)
+	v.ref = C.JS_NewUndefined()
 }
 
 // Context returns the context of the value.
@@ -690,7 +701,7 @@ func (v *Value) IsClassInstance() bool {
 // HasInstanceData checks if the value has associated Go object data
 // This is the most reliable way to identify our class instances
 func (v *Value) HasInstanceData() bool {
-	if v == nil || !v.IsObject() {
+	if v == nil || !v.hasValidContext() || v.ctx.handleStore == nil || !v.IsObject() {
 		return false
 	}
 
@@ -730,6 +741,10 @@ func (v *Value) GetClassID() uint32 {
 // GetGoObject retrieves Go object from JavaScript class instance
 // This method extracts the opaque data stored by the constructor proxy
 func (v *Value) GetGoObject() (interface{}, error) {
+	if !v.hasValidContext() || v.ctx.handleStore == nil {
+		return nil, errors.New("value context is not available")
+	}
+
 	// First check if the value is an object
 	if !v.IsObject() {
 		return nil, errors.New("value is not an object")

--- a/value_test.go
+++ b/value_test.go
@@ -889,6 +889,38 @@ func TestValueClassInstanceEdgeCases(t *testing.T) {
 	})
 }
 
+func TestValueInternalStateHelpers(t *testing.T) {
+	var nilValue *Value
+	require.False(t, nilValue.hasValidContext())
+	require.False(t, sameContext(nilValue, nil))
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx1 := rt.NewContext()
+	defer ctx1.Close()
+	ctx2 := rt.NewContext()
+	defer ctx2.Close()
+
+	v1 := ctx1.NewInt32(1)
+	v2 := ctx1.NewInt32(2)
+	v3 := ctx2.NewInt32(3)
+	defer v1.Free()
+	defer v2.Free()
+	defer v3.Free()
+
+	require.True(t, v1.hasValidContext())
+	require.True(t, sameContext(v1, v2))
+	require.False(t, sameContext(v1, v3))
+	require.False(t, sameContext(v1, nil))
+}
+
+func TestValueGetGoObjectUnavailableContext(t *testing.T) {
+	v := &Value{}
+	_, err := v.GetGoObject()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value context is not available")
+}
+
 // TestValueCallConstructorEdgeCases tests edge cases and error conditions in CallConstructor
 // MODIFIED FOR SCHEME C: Removed all NewInstance tests, enhanced CallConstructor coverage
 func TestValueCallConstructorEdgeCases(t *testing.T) {


### PR DESCRIPTION
- add fail-closed lifecycle guards across runtime/context/value/bridge/handle store

- expand boundary and close-race contract tests for mapping corruption, callbacks, module init, and finalizer paths

- document lifecycle and boundary guarantees in README (EN/ZH)

- improve coverage-targeted tests and reach 100% statement coverage