### PR TITLE
feat: enforce owner runtime contract and migrate legacy tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The runtime sources under deps/quickjs are no longer updated via git submodule. 
 
 ### Lifecycle, Memory, and Concurrency
 - QuickJS is not thread-safe; a Runtime and its Contexts must be created, used, and closed by the same serialized owner goroutine.
-- This library enforces owner-goroutine checks by default for APIs that touch QuickJS; non-owner calls are rejected with fail-closed behavior.
+- This library enforces owner-goroutine checks by default for APIs that touch QuickJS (non-owner calls are rejected with fail-closed behavior); you can explicitly disable this with `WithOwnerGoroutineCheck(false)`, but it is an unsafe escape hatch and should be used only when your own scheduler strictly serializes all QuickJS access externally. If that guarantee is broken, cross-goroutine calls can race QuickJS internals and may cause memory corruption.
 - If you want to additionally verify that a Runtime stays fixed to the same OS thread, enable `WithStrictOSThread(true)`; this option only enables validation and does not bind the thread automatically. If you enable this mode, call `runtime.LockOSThread()` yourself in the owner goroutine before creating the Runtime.
 - Call `value.Free()` for `*Value` objects you create or receive. Runtime and Context objects must be cleaned up via `Close()`.
 - `Value.Free()` is fail-closed when its context pointer is no longer valid, avoiding unsafe cgo calls after close.
@@ -277,6 +277,8 @@ func main() {
 // NOTE:
 // - The caller owns thread affinity. Bind the owner goroutine with runtime.LockOSThread()
 //   yourself if the Runtime must stay on one OS thread.
+// - WithOwnerGoroutineCheck(false) is unsafe and should be used only when your
+//   code guarantees serialized QuickJS access externally.
 // - Goroutines must NOT call QuickJS/Context APIs directly.
 // - Always schedule back to the Context thread via ctx.Schedule
 //   before creating values or resolving/rejecting Promises.

--- a/README.md
+++ b/README.md
@@ -44,37 +44,26 @@ The runtime sources under deps/quickjs are no longer updated via git submodule. 
 
 ## Guidelines
 
+### Lifecycle, Memory, and Concurrency
+- QuickJS is not thread-safe; a Runtime and its Contexts must be created, used, and closed by the same serialized owner goroutine.
+- This library enforces owner-goroutine checks by default for APIs that touch QuickJS; non-owner calls are rejected with fail-closed behavior.
+- If you want to additionally verify that a Runtime stays fixed to the same OS thread, enable `WithStrictOSThread(true)`; this option only enables validation and does not bind the thread automatically. If you enable this mode, call `runtime.LockOSThread()` yourself in the owner goroutine before creating the Runtime.
+- Call `value.Free()` for `*Value` objects you create or receive. Runtime and Context objects must be cleaned up via `Close()`.
+- `Value.Free()` is fail-closed when its context pointer is no longer valid, avoiding unsafe cgo calls after close.
+- After `Context.Close()`, boundary queries are fail-closed: `Runtime()` returns `nil`, `HasException()` returns `false`, `Exception()` returns `nil`, `Loop()` becomes a no-op, and `Schedule()` returns `false`.
+- Bridge mapping and handle-store reads are fail-closed under corrupted entries (wrong types), preventing panic-based crashes.
+- Class instance opaque data is resolved via runtime-scoped object identity (`contextID` + `handleID`), so finalizer and `Value.GetGoObject()` use deterministic ownership lookup.
+- Go callbacks returning `nil` from function/method/getter/setter proxies are normalized to JavaScript `undefined`.
+- Module exports are validated during module initialization: export values must be non-`nil`, context-live, and belong to the initializing context.
+- Use `runtime.SetFinalizer()` cautiously as it may interfere with QuickJS GC.
+- For concurrency or isolation, use a thread pool pattern with pre-initialized runtimes, or separate Runtime/Context instances by task/user.
+- Reuse Runtime and Context objects when possible, avoid frequent Go/JS value conversion, and consider bytecode compilation for frequently executed scripts.
+
 ### Error Handling
 - Use `Value.IsException()` or `Context.HasException()` to check for exceptions
 - Use `Context.Exception()` to get the exception as a Go error
 - Always call `defer value.Free()` for returned values to prevent memory leaks
 - Check `Context.HasException()` after operations that might throw
-
-### Memory Management
-- Call  `value.Free()` for `*Value` objects you create or receive. QuickJS uses reference counting for memory management, so if a value is referenced by other objects, you only need to ensure the referencing objects are properly freed.
-- Runtime and Context objects have their own cleanup methods (`Close()`). Close them once you are done using them.
-- Use `runtime.SetFinalizer()` cautiously as it may interfere with QuickJS's GC.
-
-### Lifecycle and Boundary Contracts
-- After `Context.Close()`, boundary queries are fail-closed: `Runtime()` returns `nil`, `HasException()` returns `false`, `Exception()` returns `nil`, `Loop()` becomes a no-op, and `Schedule()` returns `false`.
-- `Value.Free()` is fail-closed when its context pointer is no longer valid, avoiding unsafe cgo calls after close.
-- Bridge mapping and handle-store reads are fail-closed under corrupted entries (wrong types), preventing panic-based crashes.
-- Class instance opaque data is resolved via runtime-scoped object identity (`contextID` + `handleID`), so finalizer and `Value.GetGoObject()` use deterministic ownership lookup instead of scanning all contexts.
-- Go callbacks returning `nil` from function/method/getter/setter proxies are normalized to JavaScript `undefined`.
-- Module exports are validated during module initialization: export values must be non-`nil`, context-live, and belong to the initializing context.
-
-### Performance Tips
-- QuickJS is not thread-safe. For concurrency or isolation, use a thread pool pattern with pre-initialized runtimes, or manage separate Runtime/Context instances for different tasks or users.
-- Thread affinity is the caller's responsibility. This library no longer calls `runtime.LockOSThread()` / `runtime.UnlockOSThread()` internally.
-- For a given Runtime and its Contexts, create, use, and close them from one serialized owner goroutine. If you need strict OS-thread affinity, call `runtime.LockOSThread()` in that owner goroutine yourself before creating the Runtime.
-- Reuse Runtime and Context objects when possible.
-- Avoid frequent conversion between Go and JS values.
-- Consider using bytecode compilation for frequently executed scripts.
-
-### Best Practices
-- Use appropriate `EvalOptions` for different script types.
-- Handle both JavaScript exceptions and Go errors appropriately.
-- Test memory usage under load to prevent leaks.
 
 
 ## Usage

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -46,7 +46,7 @@ deps/quickjs 中的运行时源码不再通过 git submodule 更新，而是按 
 
 ### 生命周期、内存与并发约束
 - QuickJS 本身不是线程安全的；同一个 Runtime 及其 Context 必须由同一个串行 owner goroutine 创建、使用和关闭。
-- 库会默认对触达 QuickJS 的 API 强制执行 owner goroutine 校验；非 owner 调用会按 fail-closed 语义拒绝。
+- 库默认对触达 QuickJS 的 API 强制执行 owner goroutine 校验（非 owner 调用按 fail-closed 语义拒绝）；可以使用`WithOwnerGoroutineCheck(false)`显示关闭 owner goroutine 校验,  注意`WithOwnerGoroutineCheck(false)` 是显式不安全开关，仅适用于由你自己的调度器在外部严格串行化所有 QuickJS 访问的场景，一旦该前提被破坏，跨 goroutine 调用可能与 QuickJS 内部状态竞争并导致内存破坏。
 - 如需额外校验 Runtime 是否固定在同一个 OS 线程上，可启用 `WithStrictOSThread(true)`；该选项只负责校验，不会自动绑定线程。如果启用了该模式，请由调用方在 owner goroutine 中自行调用 `runtime.LockOSThread()`，并在创建 Runtime 之前完成绑定。
 - 对您创建或接收的 `*Value` 对象调用 `value.Free()`；Runtime 和 Context 使用完毕后通过 `Close()` 清理。
 - 当 `Value` 的上下文引用已失效时，`Value.Free()` 会 fail-closed，避免关闭后的不安全 cgo 调用。
@@ -275,6 +275,7 @@ func main() {
 
 // 注意：
 // - 线程归属由调用方负责；如果一个 Runtime 必须固定在同一个 OS 线程，请由调用方自行在 owner goroutine 中调用 runtime.LockOSThread()。
+// - WithOwnerGoroutineCheck(false) 是不安全开关，只应在你能保证外部串行化 QuickJS 访问时使用。
 // - 不要在 goroutine 中直接调用 Context 或任何 QuickJS API。
 // - 所有 QuickJS 相关操作都应该通过 ctx.Schedule 调度回 Context 线程后再执行。
 // - ctx.Await 会在内部驱动 pending jobs 和调度器，直至 Promise 解决。

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -44,37 +44,26 @@ deps/quickjs 中的运行时源码不再通过 git submodule 更新，而是按 
 
 ## 使用指南
 
+### 生命周期、内存与并发约束
+- QuickJS 本身不是线程安全的；同一个 Runtime 及其 Context 必须由同一个串行 owner goroutine 创建、使用和关闭。
+- 库会默认对触达 QuickJS 的 API 强制执行 owner goroutine 校验；非 owner 调用会按 fail-closed 语义拒绝。
+- 如需额外校验 Runtime 是否固定在同一个 OS 线程上，可启用 `WithStrictOSThread(true)`；该选项只负责校验，不会自动绑定线程。如果启用了该模式，请由调用方在 owner goroutine 中自行调用 `runtime.LockOSThread()`，并在创建 Runtime 之前完成绑定。
+- 对您创建或接收的 `*Value` 对象调用 `value.Free()`；Runtime 和 Context 使用完毕后通过 `Close()` 清理。
+- 当 `Value` 的上下文引用已失效时，`Value.Free()` 会 fail-closed，避免关闭后的不安全 cgo 调用。
+- 在 `Context.Close()` 之后，边界查询采用 fail-closed：`Runtime()` 返回 `nil`，`HasException()` 返回 `false`，`Exception()` 返回 `nil`，`Loop()` 变为 no-op，`Schedule()` 返回 `false`。
+- bridge 映射和 handleStore 在遇到损坏条目（错误类型）时采用 fail-closed，避免 panic 级崩溃。
+- 类实例 opaque 数据通过 runtime 级对象身份（`contextID` + `handleID`）解析，finalizer 与 `Value.GetGoObject()` 使用确定性归属定位。
+- Go 回调在 function/method/getter/setter 代理里返回 `nil` 时，会统一映射为 JavaScript `undefined`。
+- 模块初始化阶段会校验导出值：导出值必须非 `nil`、上下文可用且属于当前初始化上下文。
+- 谨慎使用 `runtime.SetFinalizer()`，因为它可能干扰 QuickJS GC。
+- 如需并发或隔离，建议使用线程池预初始化运行时，或为不同任务/用户管理独立 Runtime/Context。
+- 尽可能复用 Runtime/Context，减少 Go 与 JS 值之间的频繁转换；高频脚本建议使用字节码编译。
+
 ### 错误处理
 - 使用 `Value.IsException()` 或 `Context.HasException()` 检查异常
 - 使用 `Context.Exception()` 获取异常作为 Go error
 - 始终对返回的值调用 `defer value.Free()` 以防止内存泄漏
 - 在可能抛出异常的操作后检查 `Context.HasException()`
-
-### 内存管理
-- 对您创建或接收的 `*Value` 对象调用 `value.Free()`。QuickJS 使用引用计数进行内存管理，因此如果一个值被其他对象引用，您只需要确保引用对象被正确释放。
-- Runtime 和 Context 对象有自己的清理方法 (`Close()`)。使用完毕后立即关闭它们。
-- 谨慎使用 `runtime.SetFinalizer()`，因为它可能会干扰 QuickJS 的 GC。
-
-### 生命周期与边界契约
-- 在 `Context.Close()` 之后，边界查询采用 fail-closed 语义：`Runtime()` 返回 `nil`，`HasException()` 返回 `false`，`Exception()` 返回 `nil`，`Loop()` 变为 no-op，`Schedule()` 返回 `false`。
-- 当 `Value` 的上下文引用已失效时，`Value.Free()` 会 fail-closed，避免关闭后的不安全 cgo 调用。
-- bridge 映射和 handleStore 在遇到损坏条目（错误类型）时采用 fail-closed，避免 panic 级崩溃。
-- 类实例 opaque 数据通过 runtime 级对象身份（`contextID` + `handleID`）解析，finalizer 与 `Value.GetGoObject()` 使用确定性归属定位，不再通过遍历所有 context 猜测归属。
-- Go 回调在 function/method/getter/setter 代理里返回 `nil` 时，会统一映射为 JavaScript `undefined`。
-- 模块初始化阶段会校验导出值：导出值必须非 `nil`、上下文可用且属于当前初始化上下文。
-
-### 性能建议
-- QuickJS 不是线程安全的。如需并发或隔离，建议使用线程池模式预初始化运行时，或为不同任务/用户管理独立的 Runtime/Context 实例。
-- 线程归属由调用方自己负责。当前库不再在内部偷偷调用 `runtime.LockOSThread()` / `runtime.UnlockOSThread()`。
-- 对同一个 Runtime 及其 Context，创建、使用和关闭都应由同一个串行 owner goroutine 负责。如果你需要严格的 OS 线程绑定，请在这个 owner goroutine 里先自行调用 `runtime.LockOSThread()`，再创建 Runtime。
-- 尽可能复用 Runtime 和 Context 对象
-- 避免频繁在 Go 和 JS 值之间转换
-- 对于频繁执行的脚本建议使用字节码编译
-
-### 最佳实践
-- 针对不同脚本类型使用合适的 `EvalOptions`
-- 正确处理 JavaScript 异常和 Go 错误
-- 在高负载下测试内存使用，防止泄漏
 
 ## 用法
 

--- a/atom_deprecated_test.go
+++ b/atom_deprecated_test.go
@@ -9,12 +9,19 @@ import (
 // TestDeprecatedAtomAPIs tests all deprecated Atom methods to ensure they still work
 // Each deprecated method is called once for test coverage
 func TestDeprecatedAtomAPIs(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	t.Run("DeprecatedAtomStringMethod", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated String() method on Atom
 		atom := ctx.NewAtom("test atom")
 		defer atom.Free()
@@ -32,6 +39,7 @@ func TestDeprecatedAtomAPIs(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomValueMethod", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated Value() method on Atom
 		atom := ctx.NewAtom("value test")
 		defer atom.Free()
@@ -68,6 +76,7 @@ func TestDeprecatedAtomAPIs(t *testing.T) {
 
 		for _, testCase := range testCases {
 			t.Run("AtomCase_"+testCase, func(t *testing.T) {
+				ctx := newTestContext(t)
 				atom := ctx.NewAtom(testCase)
 				defer atom.Free()
 
@@ -84,6 +93,7 @@ func TestDeprecatedAtomAPIs(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomWithPropertyAccess", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated Atom methods in property access scenarios
 		obj := ctx.NewObject()
 		defer obj.Free()
@@ -108,6 +118,7 @@ func TestDeprecatedAtomAPIs(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomComparison", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test that deprecated methods work consistently
 		atom1 := ctx.NewAtom("comparison test")
 		atom2 := ctx.NewAtom("comparison test")
@@ -130,10 +141,16 @@ func TestDeprecatedAtomAPIs(t *testing.T) {
 
 // TestDeprecatedAtomEdgeCases tests edge cases with deprecated Atom methods
 func TestDeprecatedAtomEdgeCases(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	t.Run("DeprecatedAtomWithUnicodeStrings", func(t *testing.T) {
 		// Test deprecated methods with Unicode strings
@@ -147,6 +164,7 @@ func TestDeprecatedAtomEdgeCases(t *testing.T) {
 
 		for _, unicodeStr := range unicodeStrings {
 			t.Run("Unicode_"+unicodeStr, func(t *testing.T) {
+				ctx := newTestContext(t)
 				atom := ctx.NewAtom(unicodeStr)
 				defer atom.Free()
 
@@ -163,6 +181,7 @@ func TestDeprecatedAtomEdgeCases(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomMemoryManagement", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test that deprecated methods don't cause memory issues
 		for i := 0; i < 100; i++ {
 			atom := ctx.NewAtom("memory test " + string(rune('A'+i%26)))
@@ -179,6 +198,7 @@ func TestDeprecatedAtomEdgeCases(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomWithLongStrings", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated methods with very long strings
 		longString := ""
 		for i := 0; i < 1000; i++ {
@@ -202,12 +222,19 @@ func TestDeprecatedAtomEdgeCases(t *testing.T) {
 
 // TestDeprecatedAtomInteractionWithContext tests how deprecated Atom methods interact with Context
 func TestDeprecatedAtomInteractionWithContext(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	t.Run("DeprecatedAtomInJavaScriptCode", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Create atom using new API
 		atom := ctx.NewAtom("globalTestVar")
 		defer atom.Free()
@@ -225,6 +252,7 @@ func TestDeprecatedAtomInteractionWithContext(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomValueInJavaScript", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Create atom
 		atom := ctx.NewAtom("javascript interaction")
 		defer atom.Free()
@@ -242,6 +270,7 @@ func TestDeprecatedAtomInteractionWithContext(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomWithJavaScriptExecution", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test using deprecated atom methods in JavaScript execution context
 		atom := ctx.NewAtom("dynamicProperty")
 		defer atom.Free()

--- a/atom_test.go
+++ b/atom_test.go
@@ -46,11 +46,16 @@ func TestAtomBasics(t *testing.T) {
 
 // TestAtomSpecialCases tests special characters and edge cases
 func TestAtomSpecialCases(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	// Test various special characters and edge cases
 	testCases := []struct {
@@ -72,6 +77,7 @@ func TestAtomSpecialCases(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestContext(t)
 			var atom *Atom
 
 			switch v := tc.input.(type) {
@@ -92,6 +98,7 @@ func TestAtomSpecialCases(t *testing.T) {
 	}
 
 	// Test long string
+	ctx := newTestContext(t)
 	longString := strings.Repeat("a", 5000)
 	longAtom := ctx.NewAtom(longString) // Changed: Atom() → NewAtom()
 	defer longAtom.Free()
@@ -225,12 +232,19 @@ func TestAtomDeduplication(t *testing.T) {
 
 // TestAtomEdgeCases tests additional edge cases for better coverage
 func TestAtomEdgeCases(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	t.Run("AtomWithUnicodeStrings", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test atom creation with various Unicode strings
 		unicodeStrings := []string{
 			"中文测试",
@@ -256,6 +270,7 @@ func TestAtomEdgeCases(t *testing.T) {
 	})
 
 	t.Run("AtomWithSpecialCharacters", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test atoms with special characters that could cause issues
 		specialStrings := []string{
 			"",            // empty string
@@ -281,6 +296,7 @@ func TestAtomEdgeCases(t *testing.T) {
 	})
 
 	t.Run("AtomWithLargeIndexes", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test atoms created with various index values
 		indexes := []uint32{
 			0,
@@ -308,6 +324,7 @@ func TestAtomEdgeCases(t *testing.T) {
 	})
 
 	t.Run("AtomConsistency", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test that atoms with same content are handled consistently
 		testString := "consistency_test"
 
@@ -329,6 +346,7 @@ func TestAtomEdgeCases(t *testing.T) {
 	})
 
 	t.Run("AtomPropertyAccess", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test using atoms for property access
 		obj := ctx.NewObject() // Changed: Object() → NewObject()
 		defer obj.Free()

--- a/bridge.c
+++ b/bridge.c
@@ -10,10 +10,23 @@
 #elif defined(__APPLE__)
 #include <pthread.h>
 #elif defined(__linux__)
+#include <pthread.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 #else
 #include <pthread.h>
+#endif
+
+#ifdef _WIN32
+typedef SRWLOCK qjsgo_mutex_t;
+#define QJSGO_MUTEX_INITIALIZER SRWLOCK_INIT
+#define qjsgo_mutex_lock(mu) AcquireSRWLockExclusive((mu))
+#define qjsgo_mutex_unlock(mu) ReleaseSRWLockExclusive((mu))
+#else
+typedef pthread_mutex_t qjsgo_mutex_t;
+#define QJSGO_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+#define qjsgo_mutex_lock(mu) pthread_mutex_lock((mu))
+#define qjsgo_mutex_unlock(mu) pthread_mutex_unlock((mu))
 #endif
 
 // ============================================================================
@@ -54,13 +67,13 @@ static int isExecuteTimeoutExceeded(JSRuntime *rt);
 static int ThrowUnhandledPromiseRejectionIfAny(JSContext *ctx);
 
 static int g_await_poll_slice_ms = 10;
-static pthread_mutex_t g_await_poll_slice_mu = PTHREAD_MUTEX_INITIALIZER;
+static qjsgo_mutex_t g_await_poll_slice_mu = QJSGO_MUTEX_INITIALIZER;
 
 int GetAwaitPollSliceMs(void) {
     int value;
-    pthread_mutex_lock(&g_await_poll_slice_mu);
+    qjsgo_mutex_lock(&g_await_poll_slice_mu);
     value = g_await_poll_slice_ms;
-    pthread_mutex_unlock(&g_await_poll_slice_mu);
+    qjsgo_mutex_unlock(&g_await_poll_slice_mu);
     return value;
 }
 
@@ -83,9 +96,9 @@ void SetAwaitPollSliceMs(int timeout_ms) {
         return;
     }
 
-    pthread_mutex_lock(&g_await_poll_slice_mu);
+    qjsgo_mutex_lock(&g_await_poll_slice_mu);
     g_await_poll_slice_ms = timeout_ms;
-    pthread_mutex_unlock(&g_await_poll_slice_mu);
+    qjsgo_mutex_unlock(&g_await_poll_slice_mu);
 }
 
 typedef struct RejectionEntry {
@@ -102,7 +115,7 @@ typedef struct RejectionStateEntry {
 } RejectionStateEntry;
 
 static RejectionStateEntry *g_rejection_states = NULL;
-static pthread_mutex_t g_rejection_states_mu = PTHREAD_MUTEX_INITIALIZER;
+static qjsgo_mutex_t g_rejection_states_mu = QJSGO_MUTEX_INITIALIZER;
 
 static void freeRejectionEntry(JSRuntime *rt, RejectionEntry *entry) {
     if (!entry) {
@@ -140,7 +153,7 @@ static RejectionStateEntry *getRejectionState(JSRuntime *rt, int create) {
 }
 
 static void clearRejectionState(JSRuntime *rt) {
-    pthread_mutex_lock(&g_rejection_states_mu);
+    qjsgo_mutex_lock(&g_rejection_states_mu);
 
     RejectionStateEntry *prev = NULL;
     RejectionStateEntry *current = g_rejection_states;
@@ -165,7 +178,7 @@ static void clearRejectionState(JSRuntime *rt) {
         current = current->next;
     }
 
-    pthread_mutex_unlock(&g_rejection_states_mu);
+    qjsgo_mutex_unlock(&g_rejection_states_mu);
 }
 
 static void QuickjsGoPromiseRejectionTracker(JSContext *ctx,
@@ -176,10 +189,10 @@ static void QuickjsGoPromiseRejectionTracker(JSContext *ctx,
     JSRuntime *rt = JS_GetRuntime(ctx);
     (void)opaque;
 
-    pthread_mutex_lock(&g_rejection_states_mu);
+    qjsgo_mutex_lock(&g_rejection_states_mu);
     RejectionStateEntry *state = getRejectionState(rt, 1);
     if (!state) {
-        pthread_mutex_unlock(&g_rejection_states_mu);
+        qjsgo_mutex_unlock(&g_rejection_states_mu);
         return;
     }
 
@@ -205,20 +218,20 @@ static void QuickjsGoPromiseRejectionTracker(JSContext *ctx,
             }
             freeRejectionEntry(rt, current);
         }
-        pthread_mutex_unlock(&g_rejection_states_mu);
+        qjsgo_mutex_unlock(&g_rejection_states_mu);
         return;
     }
 
     if (current) {
         JS_FreeValueRT(rt, current->reason);
         current->reason = JS_DupValueRT(rt, reason);
-        pthread_mutex_unlock(&g_rejection_states_mu);
+        qjsgo_mutex_unlock(&g_rejection_states_mu);
         return;
     }
 
     RejectionEntry *entry = malloc(sizeof(RejectionEntry));
     if (!entry) {
-        pthread_mutex_unlock(&g_rejection_states_mu);
+        qjsgo_mutex_unlock(&g_rejection_states_mu);
         return;
     }
 
@@ -233,7 +246,7 @@ static void QuickjsGoPromiseRejectionTracker(JSContext *ctx,
     }
     state->tail = entry;
 
-    pthread_mutex_unlock(&g_rejection_states_mu);
+    qjsgo_mutex_unlock(&g_rejection_states_mu);
 }
 
 void SetPromiseRejectionTracker(JSRuntime *rt, int enabled) {
@@ -253,10 +266,10 @@ void SetPromiseRejectionTracker(JSRuntime *rt, int enabled) {
 static int popUnhandledPromiseRejection(JSContext *ctx, JSValue *reason_out) {
     JSRuntime *rt = JS_GetRuntime(ctx);
 
-    pthread_mutex_lock(&g_rejection_states_mu);
+    qjsgo_mutex_lock(&g_rejection_states_mu);
     RejectionStateEntry *state = getRejectionState(rt, 0);
     if (!state || !state->head) {
-        pthread_mutex_unlock(&g_rejection_states_mu);
+        qjsgo_mutex_unlock(&g_rejection_states_mu);
         return 0;
     }
 
@@ -270,7 +283,7 @@ static int popUnhandledPromiseRejection(JSContext *ctx, JSValue *reason_out) {
     JS_FreeValueRT(rt, entry->promise);
     free(entry);
 
-    pthread_mutex_unlock(&g_rejection_states_mu);
+    qjsgo_mutex_unlock(&g_rejection_states_mu);
     return 1;
 }
 
@@ -877,14 +890,14 @@ typedef struct TimeoutStateEntry {
 } TimeoutStateEntry;
 
 static TimeoutStateEntry *g_timeout_states = NULL;
-static pthread_mutex_t g_timeout_states_mu = PTHREAD_MUTEX_INITIALIZER;
+static qjsgo_mutex_t g_timeout_states_mu = QJSGO_MUTEX_INITIALIZER;
 
 static int isExecuteTimeoutExceeded(JSRuntime *rt) {
     time_t start = 0;
     time_t timeout = 0;
     int found = 0;
 
-    pthread_mutex_lock(&g_timeout_states_mu);
+    qjsgo_mutex_lock(&g_timeout_states_mu);
     TimeoutStateEntry *current = g_timeout_states;
     while (current) {
         if (current->rt == rt && current->state != NULL) {
@@ -895,7 +908,7 @@ static int isExecuteTimeoutExceeded(JSRuntime *rt) {
         }
         current = current->next;
     }
-    pthread_mutex_unlock(&g_timeout_states_mu);
+    qjsgo_mutex_unlock(&g_timeout_states_mu);
 
     if (!found || timeout <= 0) {
         return 0;
@@ -904,7 +917,7 @@ static int isExecuteTimeoutExceeded(JSRuntime *rt) {
     return (time(NULL) - start) > timeout;
 }
 static TimeoutStruct *takeTimeoutState(JSRuntime *rt) {
-    pthread_mutex_lock(&g_timeout_states_mu);
+    qjsgo_mutex_lock(&g_timeout_states_mu);
 
     TimeoutStateEntry *prev = NULL;
     TimeoutStateEntry *current = g_timeout_states;
@@ -917,19 +930,19 @@ static TimeoutStruct *takeTimeoutState(JSRuntime *rt) {
                 g_timeout_states = current->next;
             }
             free(current);
-            pthread_mutex_unlock(&g_timeout_states_mu);
+            qjsgo_mutex_unlock(&g_timeout_states_mu);
             return state;
         }
         prev = current;
         current = current->next;
     }
 
-    pthread_mutex_unlock(&g_timeout_states_mu);
+    qjsgo_mutex_unlock(&g_timeout_states_mu);
     return NULL;
 }
 
 static int setTimeoutState(JSRuntime *rt, TimeoutStruct *state) {
-    pthread_mutex_lock(&g_timeout_states_mu);
+    qjsgo_mutex_lock(&g_timeout_states_mu);
 
     TimeoutStateEntry *current = g_timeout_states;
     while (current) {
@@ -938,7 +951,7 @@ static int setTimeoutState(JSRuntime *rt, TimeoutStruct *state) {
                 free(current->state);
             }
             current->state = state;
-            pthread_mutex_unlock(&g_timeout_states_mu);
+            qjsgo_mutex_unlock(&g_timeout_states_mu);
             return 0;
         }
         current = current->next;
@@ -946,7 +959,7 @@ static int setTimeoutState(JSRuntime *rt, TimeoutStruct *state) {
 
     TimeoutStateEntry *entry = malloc(sizeof(TimeoutStateEntry));
     if (!entry) {
-        pthread_mutex_unlock(&g_timeout_states_mu);
+        qjsgo_mutex_unlock(&g_timeout_states_mu);
         return -1;
     }
     entry->rt = rt;
@@ -954,7 +967,7 @@ static int setTimeoutState(JSRuntime *rt, TimeoutStruct *state) {
     entry->next = g_timeout_states;
     g_timeout_states = entry;
 
-    pthread_mutex_unlock(&g_timeout_states_mu);
+    qjsgo_mutex_unlock(&g_timeout_states_mu);
     return 0;
 }
 
@@ -968,7 +981,7 @@ static void clearTimeoutState(JSRuntime *rt) {
 int GetTimeoutOpaqueCount(void) {
     int count = 0;
 
-    pthread_mutex_lock(&g_timeout_states_mu);
+    qjsgo_mutex_lock(&g_timeout_states_mu);
     TimeoutStateEntry *current = g_timeout_states;
     while (current) {
         if (current->state != NULL) {
@@ -976,7 +989,7 @@ int GetTimeoutOpaqueCount(void) {
         }
         current = current->next;
     }
-    pthread_mutex_unlock(&g_timeout_states_mu);
+    qjsgo_mutex_unlock(&g_timeout_states_mu);
 
     return count;
 }

--- a/bridge.c
+++ b/bridge.c
@@ -2,9 +2,19 @@
 #include "quickjs.h"
 #include "quickjs-libc.h"
 #include "cutils.h" 
-#include <pthread.h>
 #include <stdint.h>
 #include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#elif defined(__APPLE__)
+#include <pthread.h>
+#elif defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#else
+#include <pthread.h>
+#endif
 
 // ============================================================================
 // MACRO WRAPPER FUNCTIONS
@@ -55,7 +65,17 @@ int GetAwaitPollSliceMs(void) {
 }
 
 uint64_t CurrentThreadID(void) {
+#ifdef _WIN32
+    return (uint64_t)GetCurrentThreadId();
+#elif defined(__APPLE__)
+    uint64_t tid = 0;
+    (void)pthread_threadid_np(NULL, &tid);
+    return tid;
+#elif defined(__linux__)
+    return (uint64_t)syscall(SYS_gettid);
+#else
     return (uint64_t)(uintptr_t)pthread_self();
+#endif
 }
 
 void SetAwaitPollSliceMs(int timeout_ms) {

--- a/bridge.c
+++ b/bridge.c
@@ -3,6 +3,7 @@
 #include "quickjs-libc.h"
 #include "cutils.h" 
 #include <pthread.h>
+#include <stdint.h>
 #include <time.h>
 
 // ============================================================================
@@ -51,6 +52,10 @@ int GetAwaitPollSliceMs(void) {
     value = g_await_poll_slice_ms;
     pthread_mutex_unlock(&g_await_poll_slice_mu);
     return value;
+}
+
+uint64_t CurrentThreadID(void) {
+    return (uint64_t)(uintptr_t)pthread_self();
 }
 
 void SetAwaitPollSliceMs(int timeout_ms) {

--- a/bridge.h
+++ b/bridge.h
@@ -120,6 +120,7 @@ extern JSValue LoadModuleBytecode(JSContext *ctx, const uint8_t *buf, size_t buf
 extern int GetAwaitPollSliceMs(void);
 extern void SetAwaitPollSliceMs(int timeout_ms);
 extern int QuickjsGoPollInterrupt(JSContext *ctx);
+extern uint64_t CurrentThreadID(void);
 
 // Simplified interrupt handler interface (no handlerArgs complexity)
 extern void SetInterruptHandler(JSRuntime *rt);

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -314,12 +314,19 @@ func TestBridgeNilCallbackResultsNormalizeToUndefined(t *testing.T) {
 }
 
 func TestBridgeModuleInitFailClosedInvalidExportAndBuilderHandle(t *testing.T) {
-	rt := NewRuntime(WithModuleImport(true))
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newModuleContext := func(t *testing.T) *Context {
+		rt := NewRuntime(WithModuleImport(true))
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	t.Run("InvalidExportValue", func(t *testing.T) {
+		ctx := newModuleContext(t)
 		mb := NewModuleBuilder("invalid-export-module").
 			Export("bad", nil)
 		require.NoError(t, mb.Build(ctx))
@@ -333,6 +340,7 @@ func TestBridgeModuleInitFailClosedInvalidExportAndBuilderHandle(t *testing.T) {
 	})
 
 	t.Run("InvalidModuleBuilderHandle", func(t *testing.T) {
+		ctx := newModuleContext(t)
 		mb := NewModuleBuilder("invalid-builder-module").
 			Export("ok", ctx.NewString("value"))
 		require.NoError(t, mb.Build(ctx))

--- a/class_reflect_test.go
+++ b/class_reflect_test.go
@@ -258,15 +258,16 @@ func TestReflectionMultipleReturnValues(t *testing.T) {
 // =============================================================================
 
 func TestReflectionConstructorModes(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
-
-	constructor, _ := ctx.BindClass(&Person{})
-	require.False(t, constructor.IsException())
-
-	ctx.Globals().Set("Person", constructor)
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	testCases := []struct {
 		name string
@@ -297,6 +298,11 @@ func TestReflectionConstructorModes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestContext(t)
+			constructor, _ := ctx.BindClass(&Person{})
+			require.False(t, constructor.IsException())
+			ctx.Globals().Set("Person", constructor)
+
 			result := ctx.Eval(fmt.Sprintf(`
                 (function() {
                     let person = %s;
@@ -430,13 +436,20 @@ func TestReflectionWithIgnoredMethods(t *testing.T) {
 // =============================================================================
 
 func TestReflectionInputValidation(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	// Test reflect.Type input with non-struct type
 	t.Run("NonStructReflectType", func(t *testing.T) {
+		ctx := newTestContext(t)
 		intType := reflect.TypeOf(42)
 		_, err := ctx.BindClassBuilder(intType)
 		require.Error(t, err)
@@ -445,6 +458,7 @@ func TestReflectionInputValidation(t *testing.T) {
 
 	// Test pointer to non-struct
 	t.Run("PointerToNonStruct", func(t *testing.T) {
+		ctx := newTestContext(t)
 		intPtr := new(int)
 		_, err := ctx.BindClassBuilder(intPtr)
 		require.Error(t, err)
@@ -453,6 +467,7 @@ func TestReflectionInputValidation(t *testing.T) {
 
 	// Test non-struct direct value
 	t.Run("NonStructValue", func(t *testing.T) {
+		ctx := newTestContext(t)
 		_, err := ctx.BindClassBuilder(42)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "value must be a struct or pointer to struct")
@@ -460,6 +475,7 @@ func TestReflectionInputValidation(t *testing.T) {
 
 	// Test nil input
 	t.Run("NilInput", func(t *testing.T) {
+		ctx := newTestContext(t)
 		_, err := ctx.BindClassBuilder(nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "cannot get type from nil value")
@@ -467,6 +483,7 @@ func TestReflectionInputValidation(t *testing.T) {
 
 	// Test anonymous struct types - these should fail because they have no class name
 	t.Run("AnonymousStructValue", func(t *testing.T) {
+		ctx := newTestContext(t)
 		anonymousStruct := struct {
 			Name string `js:"name"`
 			Age  int    `js:"age"`
@@ -478,6 +495,7 @@ func TestReflectionInputValidation(t *testing.T) {
 	})
 
 	t.Run("AnonymousStructPointer", func(t *testing.T) {
+		ctx := newTestContext(t)
 		anonymousStructPtr := &struct {
 			Name string `js:"name"`
 			Age  int    `js:"age"`
@@ -489,6 +507,7 @@ func TestReflectionInputValidation(t *testing.T) {
 	})
 
 	t.Run("AnonymousStructReflectType", func(t *testing.T) {
+		ctx := newTestContext(t)
 		anonymousStruct := struct {
 			Name string `js:"name"`
 			Age  int    `js:"age"`
@@ -514,6 +533,7 @@ func TestReflectionInputValidation(t *testing.T) {
 
 	for _, tc := range errorCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestContext(t)
 			_, err := ctx.BindClassBuilder(tc.input)
 			require.Error(t, err)
 		})
@@ -521,18 +541,23 @@ func TestReflectionInputValidation(t *testing.T) {
 }
 
 func TestReflectionMethodArgumentErrors(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
-
-	constructor, _ := ctx.BindClass(&MethodTestStruct{})
-	require.False(t, constructor.IsException())
-
-	ctx.Globals().Set("MethodTest", constructor)
+	newMethodTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		constructor, _ := ctx.BindClass(&MethodTestStruct{})
+		require.False(t, constructor.IsException())
+		ctx.Globals().Set("MethodTest", constructor)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	// Test too many arguments
 	t.Run("TooManyArguments", func(t *testing.T) {
+		ctx := newMethodTestContext(t)
 		result := ctx.Eval(`
             (function() {
                 let obj = new MethodTest();
@@ -551,6 +576,7 @@ func TestReflectionMethodArgumentErrors(t *testing.T) {
 
 	// Test argument conversion errors
 	t.Run("ArgumentConversionError", func(t *testing.T) {
+		ctx := newMethodTestContext(t)
 		result := ctx.Eval(`
             (function() {
                 let obj = new MethodTest();
@@ -569,6 +595,7 @@ func TestReflectionMethodArgumentErrors(t *testing.T) {
 
 	// Test missing arguments (zero value filling)
 	t.Run("MissingArguments", func(t *testing.T) {
+		ctx := newMethodTestContext(t)
 		result := ctx.Eval(`
             (function() {
                 let obj = new MethodTest();
@@ -587,17 +614,23 @@ func TestReflectionMethodArgumentErrors(t *testing.T) {
 // =============================================================================
 
 func TestReflectionConstructorErrors(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
-
-	constructor, _ := ctx.BindClass(&Person{})
-	require.False(t, constructor.IsException())
-	ctx.Globals().Set("Person", constructor)
+	newPersonTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		constructor, _ := ctx.BindClass(&Person{})
+		require.False(t, constructor.IsException())
+		ctx.Globals().Set("Person", constructor)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	// Test positional argument conversion error
 	t.Run("PositionalArgumentError", func(t *testing.T) {
+		ctx := newPersonTestContext(t)
 		ret := ctx.Eval(`
             try {
                 // Pass an object where an int is expected for age
@@ -616,6 +649,7 @@ func TestReflectionConstructorErrors(t *testing.T) {
 
 	// Test object argument conversion error
 	t.Run("ObjectArgumentError", func(t *testing.T) {
+		ctx := newPersonTestContext(t)
 		ret := ctx.Eval(`
             try {
                 // Pass an object where an int is expected for age accessor
@@ -638,6 +672,7 @@ func TestReflectionConstructorErrors(t *testing.T) {
 
 	// Test positional args with unexported fields - covers the continue branch
 	t.Run("PositionalArgsSkipUnexportedFields", func(t *testing.T) {
+		ctx := newPersonTestContext(t)
 		// Person struct has: FirstName, LastName, Age, Salary, IsActive (exported)
 		// and private (unexported) - this should be skipped during positional initialization
 		result := ctx.Eval(`
@@ -836,13 +871,20 @@ func TestReflectionComplexTypes(t *testing.T) {
 }
 
 func TestReflectionEdgeCases(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	// Test empty struct
 	t.Run("EmptyStruct", func(t *testing.T) {
+		ctx := newTestContext(t)
 		constructor, _ := ctx.BindClass(&EmptyStruct{})
 		require.False(t, constructor.IsException())
 
@@ -861,6 +903,7 @@ func TestReflectionEdgeCases(t *testing.T) {
 
 	// Test struct with only private fields
 	t.Run("OnlyPrivateFields", func(t *testing.T) {
+		ctx := newTestContext(t)
 		constructor, _ := ctx.BindClass(&PrivateStruct{})
 		require.False(t, constructor.IsException())
 
@@ -879,6 +922,7 @@ func TestReflectionEdgeCases(t *testing.T) {
 
 	// Test method with zero return values
 	t.Run("VoidMethod", func(t *testing.T) {
+		ctx := newTestContext(t)
 		constructor, _ := ctx.BindClass(&VoidStruct{})
 		require.False(t, constructor.IsException())
 
@@ -898,6 +942,7 @@ func TestReflectionEdgeCases(t *testing.T) {
 
 	// Test valid reflect.Type input
 	t.Run("ValidReflectType", func(t *testing.T) {
+		ctx := newTestContext(t)
 		personType := reflect.TypeOf(Person{})
 		constructor, _ := ctx.BindClass(personType)
 		require.False(t, constructor.IsException())

--- a/context.go
+++ b/context.go
@@ -1039,7 +1039,7 @@ func (ctx *Context) Globals() *Value {
 
 // Throw returns a context's exception value.
 func (ctx *Context) Throw(v *Value) *Value {
-	if !ctx.hasValidRef() || v == nil || !v.hasValidContext() {
+	if !ctx.hasValidRef() || v == nil || v.ctx != ctx {
 		return nil
 	}
 	return &Value{ctx: ctx, ref: C.JS_Throw(ctx.ref, v.ref)}
@@ -1050,7 +1050,8 @@ func (ctx *Context) ThrowError(err error) *Value {
 	if !ctx.hasValidRef() {
 		return nil
 	}
-	return ctx.Throw(ctx.NewError(err))
+	v := ctx.NewError(err)
+	return &Value{ctx: ctx, ref: C.JS_Throw(ctx.ref, v.ref)}
 }
 
 // ThrowSyntaxError returns a context's exception value with given error message.

--- a/context.go
+++ b/context.go
@@ -79,7 +79,7 @@ func zeroTerminatedBytes(s string) []byte {
 }
 
 func (ctx *Context) detectModuleSource(code string, codePtr *C.char) bool {
-	if !ctx.hasValidRef() || !mayContainModuleSyntax(code) {
+	if !mayContainModuleSyntax(code) || !ctx.hasValidRef() {
 		return false
 	}
 	return C.DetectModuleSourceWithProbe(ctx.ref, codePtr, C.size_t(len(code))) != 0

--- a/context.go
+++ b/context.go
@@ -31,7 +31,10 @@ type Context struct {
 
 // hasValidRef reports whether the context still has a valid native handle.
 func (ctx *Context) hasValidRef() bool {
-	return ctx != nil && ctx.ref != nil
+	if ctx == nil || ctx.ref == nil || ctx.runtime == nil {
+		return false
+	}
+	return ctx.runtime.ensureOwnerAccess()
 }
 
 // isAlive reports whether the context can safely reach QuickJS.
@@ -76,7 +79,7 @@ func zeroTerminatedBytes(s string) []byte {
 }
 
 func (ctx *Context) detectModuleSource(code string, codePtr *C.char) bool {
-	if ctx == nil || ctx.ref == nil || !mayContainModuleSyntax(code) {
+	if !ctx.hasValidRef() || !mayContainModuleSyntax(code) {
 		return false
 	}
 	return C.DetectModuleSourceWithProbe(ctx.ref, codePtr, C.size_t(len(code))) != 0
@@ -817,6 +820,10 @@ func EvalLoadOnly(loadOnly bool) EvalOption {
 // Need call Free() `quickjs.Value`'s returned by `Eval()` and `EvalFile()` and `EvalBytecode()`.
 // func (ctx *Context) Eval(code string) (*Value, error) { return ctx.EvalFile(code, "code") }
 func (ctx *Context) Eval(code string, opts ...EvalOption) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
+
 	options := EvalOptions{
 		js_eval_type_global: true,
 		filename:            "<input>",
@@ -934,6 +941,9 @@ func (ctx *Context) CompileModule(filePath string, moduleName string, opts ...Ev
 
 // LoadModuleByteCode returns a js value with given bytecode and module name.
 func (ctx *Context) LoadModuleBytecode(buf []byte, opts ...EvalOption) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	if len(buf) == 0 {
 		return ctx.ThrowSyntaxError("empty bytecode")
 	}
@@ -957,6 +967,9 @@ func (ctx *Context) LoadModuleBytecode(buf []byte, opts ...EvalOption) *Value {
 // EvalBytecode returns a js value with given bytecode.
 // Need call Free() `quickjs.Value`'s returned by `Eval()` and `EvalFile()` and `EvalBytecode()`.
 func (ctx *Context) EvalBytecode(buf []byte) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	cbuf := (*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(buf)))
 	obj := &Value{ctx: ctx, ref: C.JS_ReadObject(ctx.ref, cbuf, C.size_t(len(buf)), C.int(C.JS_READ_OBJ_BYTECODE))}
 	if obj.IsException() {
@@ -968,6 +981,9 @@ func (ctx *Context) EvalBytecode(buf []byte) *Value {
 
 // Compile returns a compiled bytecode with given code.
 func (ctx *Context) Compile(code string, opts ...EvalOption) ([]byte, error) {
+	if !ctx.hasValidRef() {
+		return nil, errOwnerAccessDenied
+	}
 	opts = append(opts, EvalFlagCompileOnly(true))
 	val := ctx.Eval(code, opts...)
 	defer val.Free()
@@ -1009,6 +1025,9 @@ func (ctx *Context) CompileFile(filePath string, opts ...EvalOption) ([]byte, er
 
 // Global returns a context's global object.
 func (ctx *Context) Globals() *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	if ctx.globals == nil {
 		ctx.globals = &Value{
 			ctx: ctx,
@@ -1020,16 +1039,25 @@ func (ctx *Context) Globals() *Value {
 
 // Throw returns a context's exception value.
 func (ctx *Context) Throw(v *Value) *Value {
+	if !ctx.hasValidRef() || v == nil || !v.hasValidContext() {
+		return nil
+	}
 	return &Value{ctx: ctx, ref: C.JS_Throw(ctx.ref, v.ref)}
 }
 
 // ThrowError returns a context's exception value with given error message.
 func (ctx *Context) ThrowError(err error) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	return ctx.Throw(ctx.NewError(err))
 }
 
 // ThrowSyntaxError returns a context's exception value with given error message.
 func (ctx *Context) ThrowSyntaxError(format string, args ...interface{}) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
@@ -1038,6 +1066,9 @@ func (ctx *Context) ThrowSyntaxError(format string, args ...interface{}) *Value 
 
 // ThrowTypeError returns a context's exception value with given error message.
 func (ctx *Context) ThrowTypeError(format string, args ...interface{}) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
@@ -1046,6 +1077,9 @@ func (ctx *Context) ThrowTypeError(format string, args ...interface{}) *Value {
 
 // ThrowReferenceError returns a context's exception value with given error message.
 func (ctx *Context) ThrowReferenceError(format string, args ...interface{}) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
@@ -1054,6 +1088,9 @@ func (ctx *Context) ThrowReferenceError(format string, args ...interface{}) *Val
 
 // ThrowRangeError returns a context's exception value with given error message.
 func (ctx *Context) ThrowRangeError(format string, args ...interface{}) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
@@ -1062,6 +1099,9 @@ func (ctx *Context) ThrowRangeError(format string, args ...interface{}) *Value {
 
 // ThrowInternalError returns a context's exception value with given error message.
 func (ctx *Context) ThrowInternalError(format string, args ...interface{}) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	cause := fmt.Sprintf(format, args...)
 	causePtr := C.CString(cause)
 	defer C.free(unsafe.Pointer(causePtr))
@@ -1105,6 +1145,9 @@ func (ctx *Context) Loop() {
 // iterations, enabling async Go bridge functions (fetch, storage, etc.) to
 // resolve Promises from goroutines without blocking the event loop.
 func (ctx *Context) Await(v *Value) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	if v == nil || !v.IsPromise() {
 		return v
 	}
@@ -1207,6 +1250,9 @@ func (ctx *Context) Await(v *Value) *Value {
 // The resolver helpers ensure only the first resolve/reject wins, matching
 // native Promise semantics.
 func (ctx *Context) NewPromise(executor func(resolve, reject func(*Value))) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
 	// Create Promise using JavaScript code to avoid complex C API reference management
 	promiseSetup := ctx.Eval(`
         (() => {

--- a/context_deprecated_test.go
+++ b/context_deprecated_test.go
@@ -10,12 +10,19 @@ import (
 // TestDeprecatedContextAPIs tests all deprecated Context methods to ensure they still work
 // Each deprecated method is called once for test coverage
 func TestDeprecatedContextAPIs(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	t.Run("DeprecatedValueCreation", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test all deprecated value creation methods
 		val1 := ctx.Null()
 		defer val1.Free()
@@ -75,6 +82,7 @@ func TestDeprecatedContextAPIs(t *testing.T) {
 	})
 
 	t.Run("DeprecatedTypedArrays", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test all deprecated TypedArray creation methods
 		val1 := ctx.Int8Array([]int8{1, 2, 3})
 		defer val1.Free()
@@ -122,6 +130,7 @@ func TestDeprecatedContextAPIs(t *testing.T) {
 	})
 
 	t.Run("DeprecatedFunctions", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated Function method
 		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			return ctx.NewString("hello")
@@ -157,6 +166,7 @@ func TestDeprecatedContextAPIs(t *testing.T) {
 	})
 
 	t.Run("DeprecatedAtomCreation", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated Atom creation methods
 		atom1 := ctx.Atom("test")
 		defer atom1.Free()
@@ -168,6 +178,7 @@ func TestDeprecatedContextAPIs(t *testing.T) {
 	})
 
 	t.Run("DeprecatedInvoke", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated Invoke method
 		fn := ctx.NewFunction(func(ctx *Context, this *Value, args []*Value) *Value {
 			if len(args) > 0 {
@@ -191,12 +202,19 @@ func TestDeprecatedContextAPIs(t *testing.T) {
 
 // TestDeprecatedContextComplexScenarios tests complex scenarios with deprecated Context APIs
 func TestDeprecatedContextComplexScenarios(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	t.Run("MixedDeprecatedAndNewAPIs", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Mix deprecated and new APIs to ensure compatibility
 		oldString := ctx.String("old api")    // deprecated
 		newString := ctx.NewString("new api") // new
@@ -212,6 +230,7 @@ func TestDeprecatedContextComplexScenarios(t *testing.T) {
 	})
 
 	t.Run("DeprecatedFunctionWithNewValues", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Use deprecated Function with new value creation methods
 		fn := ctx.Function(func(ctx *Context, this *Value, args []*Value) *Value {
 			// Use new API inside deprecated function
@@ -225,6 +244,7 @@ func TestDeprecatedContextComplexScenarios(t *testing.T) {
 	})
 
 	t.Run("DeprecatedTypedArrayConversions", func(t *testing.T) {
+		ctx := newTestContext(t)
 		// Test deprecated TypedArray creation with conversions
 		data := []int32{10, 20, 30, 40, 50}
 		arr := ctx.Int32Array(data) // deprecated

--- a/context_test.go
+++ b/context_test.go
@@ -10,17 +10,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func useStableOwnerHooksForLegacySubtests(t *testing.T) {
+	oldGIDHook := ownerCheckCurrentGoroutineID
+	oldThreadHook := ownerCheckCurrentThreadID
+	ownerCheckCurrentGoroutineID = func() uint64 { return 1 }
+	ownerCheckCurrentThreadID = func() uint64 { return 1 }
+	t.Cleanup(func() {
+		ownerCheckCurrentGoroutineID = oldGIDHook
+		ownerCheckCurrentThreadID = oldThreadHook
+	})
+}
+
 func TestContextBasics(t *testing.T) {
-	rt := NewRuntime()
-	defer rt.Close()
-	ctx := rt.NewContext()
-	defer ctx.Close()
+	newTestContext := func(t *testing.T) *Context {
+		rt := NewRuntime()
+		ctx := rt.NewContext()
+		require.NotNil(t, ctx)
+		t.Cleanup(func() {
+			ctx.Close()
+			rt.Close()
+		})
+		return ctx
+	}
 
 	// Test Runtime() method
+	ctx := newTestContext(t)
 	require.NotNil(t, ctx.Runtime())
 
 	// Test basic value creation
 	t.Run("ValueCreation", func(t *testing.T) {
+		ctx := newTestContext(t)
 		values := []struct {
 			name      string
 			createVal func() *Value     // Changed to return pointer
@@ -41,16 +60,16 @@ func TestContextBasics(t *testing.T) {
 		}
 
 		for _, tc := range values {
-			t.Run(tc.name, func(t *testing.T) {
-				val := tc.createVal()
-				defer val.Free()
-				require.True(t, tc.checkFunc(val))
-			})
+			val := tc.createVal()
+			require.NotNil(t, val, tc.name)
+			defer val.Free()
+			require.True(t, tc.checkFunc(val), tc.name)
 		}
 	})
 
 	// Test ArrayBuffer with different data sizes
 	t.Run("ArrayBuffer", func(t *testing.T) {
+		ctx := newTestContext(t)
 		testCases := [][]byte{
 			{1, 2, 3, 4, 5},
 			{},
@@ -58,12 +77,11 @@ func TestContextBasics(t *testing.T) {
 		}
 
 		for i, data := range testCases {
-			t.Run(fmt.Sprintf("Case%d", i), func(t *testing.T) {
-				ab := ctx.NewArrayBuffer(data)
-				defer ab.Free()
-				require.True(t, ab.IsByteArray())
-				require.EqualValues(t, len(data), ab.ByteLen())
-			})
+			ab := ctx.NewArrayBuffer(data)
+			require.NotNil(t, ab, fmt.Sprintf("Case%d", i))
+			defer ab.Free()
+			require.True(t, ab.IsByteArray(), fmt.Sprintf("Case%d", i))
+			require.EqualValues(t, len(data), ab.ByteLen(), fmt.Sprintf("Case%d", i))
 		}
 	})
 
@@ -153,6 +171,8 @@ func TestContextIsAliveEdgeCases(t *testing.T) {
 }
 
 func TestContextEvaluation(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -204,6 +224,8 @@ func TestContextEvaluation(t *testing.T) {
 }
 
 func TestContextBytecodeOperations(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -319,6 +341,8 @@ func TestContextBytecodeOperations(t *testing.T) {
 }
 
 func TestContextModules(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime(WithModuleImport(true))
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -552,6 +576,8 @@ func TestContextLoadModuleAwaitSetTimeoutResolution(t *testing.T) {
 }
 
 func TestContextFunctions(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -603,6 +629,8 @@ func TestContextFunctions(t *testing.T) {
 }
 
 func TestContextErrorHandling(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -658,6 +686,8 @@ func TestContextErrorHandling(t *testing.T) {
 }
 
 func TestContextUtilities(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -712,6 +742,8 @@ func TestContextUtilities(t *testing.T) {
 }
 
 func TestContextAsync(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -773,6 +805,8 @@ func TestContextAsync(t *testing.T) {
 }
 
 func TestContextPromise(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1008,6 +1042,8 @@ func TestContextPromise(t *testing.T) {
 }
 
 func TestContextScheduler(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1397,6 +1433,8 @@ func TestContextInternalsCoverage(t *testing.T) {
 }
 
 func TestContextTypedArrays(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1691,6 +1729,8 @@ func TestContextMemoryPressure(t *testing.T) {
 }
 
 func TestContextAsyncFunction(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1860,6 +1900,8 @@ func TestContextAsyncFunction(t *testing.T) {
 // TestDeprecatedAPIs tests all deprecated methods to ensure they still work
 // Each deprecated method is called once for test coverage
 func TestDeprecatedAPIs(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()

--- a/context_test.go
+++ b/context_test.go
@@ -649,6 +649,7 @@ func TestContextErrorHandling(t *testing.T) {
 			throwFn  func() *Value // Changed to return pointer
 			errorStr string
 		}{
+			{"Throw", func() *Value { return ctx.Throw(ctx.NewError(errors.New("custom throw"))) }, "custom throw"},
 			{"ThrowError", func() *Value { return ctx.ThrowError(errors.New("custom error")) }, "custom error"},
 			{"ThrowSyntax", func() *Value { return ctx.ThrowSyntaxError("syntax: %s", "invalid") }, "SyntaxError"},
 			{"ThrowType", func() *Value { return ctx.ThrowTypeError("type error") }, "TypeError"},

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -121,6 +121,8 @@ func (t *TimeWrapper) UnmarshalJS(ctx *Context, val *Value) error {
 }
 
 func TestMarshalBasicTypes(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -227,6 +229,8 @@ func TestMarshalBasicTypes(t *testing.T) {
 }
 
 func TestFieldTagParsing(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -422,6 +426,8 @@ func TestFieldTagParsing(t *testing.T) {
 }
 
 func TestCamelCaseConversion(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -475,6 +481,8 @@ func TestCamelCaseConversion(t *testing.T) {
 }
 
 func TestRoundTripWithNewTagParsing(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -531,6 +539,8 @@ func TestRoundTripWithNewTagParsing(t *testing.T) {
 }
 
 func TestTypedArrays(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -666,6 +676,8 @@ func TestTypedArrays(t *testing.T) {
 }
 
 func TestTypedArrayErrors(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -751,6 +763,8 @@ func TestTypedArrayErrors(t *testing.T) {
 }
 
 func TestComplexTypes(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -897,6 +911,8 @@ func TestComplexTypes(t *testing.T) {
 }
 
 func TestStructsAndCustomTypes(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -979,6 +995,8 @@ func TestStructsAndCustomTypes(t *testing.T) {
 }
 
 func TestUnmarshalInterface(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1048,6 +1066,8 @@ func TestUnmarshalInterface(t *testing.T) {
 }
 
 func TestErrorCases(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1247,6 +1267,8 @@ func TestErrorCases(t *testing.T) {
 }
 
 func TestIntegrationExample(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1294,7 +1316,11 @@ func TestIntegrationExample(t *testing.T) {
 }
 
 func TestMarshalNilAndInvalidValues(t *testing.T) {
-	ctx := NewRuntime().NewContext()
+	useStableOwnerHooksForLegacySubtests(t)
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
 	defer ctx.Close()
 
 	valNil, err := ctx.Marshal(nil)

--- a/module_test.go
+++ b/module_test.go
@@ -12,6 +12,8 @@ import (
 // =============================================================================
 
 func TestModuleBuilder_Basic(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -72,6 +74,8 @@ func TestModuleBuilder_Basic(t *testing.T) {
 // =============================================================================
 
 func TestModuleBuilder_Import(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -162,6 +166,8 @@ func TestModuleBuilder_Import(t *testing.T) {
 // =============================================================================
 
 func TestModuleBuilder_ErrorHandling(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -202,6 +208,8 @@ func TestModuleBuilder_ErrorHandling(t *testing.T) {
 // =============================================================================
 
 func TestModuleBuilder_Integration(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -303,6 +311,8 @@ func TestModuleBuilder_Integration(t *testing.T) {
 }
 
 func TestModuleBuilder_ErrorBranches(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()

--- a/runtime.go
+++ b/runtime.go
@@ -126,8 +126,7 @@ func (r *Runtime) claimOrVerifyOwnerGoroutine(current uint64) bool {
 func (r *Runtime) claimOrVerifyOwnerThread(current uint64) bool {
 	owner := r.ownerThreadID.Load()
 	if owner == 0 {
-		r.ownerThreadID.CompareAndSwap(0, current)
-		owner = r.ownerThreadID.Load()
+		return r.ownerThreadID.CompareAndSwap(0, current) || r.ownerThreadID.Load() == current
 	}
 	return owner == current
 }

--- a/runtime.go
+++ b/runtime.go
@@ -78,6 +78,7 @@ type Options struct {
 	canBlock             bool
 	moduleImport         bool
 	strip                int
+	ownerGoroutineCheck  bool
 	strictThreadAffinity bool
 }
 
@@ -88,12 +89,14 @@ func (r *Runtime) ensureOwnerAccess() bool {
 		return false
 	}
 
-	gid := ownerCheckCurrentGoroutineID()
-	if gid == 0 {
-		return false
-	}
-	if !r.claimOrVerifyOwnerGoroutine(gid) {
-		return false
+	if r.options == nil || r.options.ownerGoroutineCheck {
+		gid := ownerCheckCurrentGoroutineID()
+		if gid == 0 {
+			return false
+		}
+		if !r.claimOrVerifyOwnerGoroutine(gid) {
+			return false
+		}
 	}
 
 	if r.options != nil && r.options.strictThreadAffinity {
@@ -206,6 +209,14 @@ func WithStripInfo(strip int) Option {
 	}
 }
 
+// WithOwnerGoroutineCheck enables/disables owner-goroutine checks.
+// WARNING: disabling this check is unsafe and may cause data races or memory corruption.
+func WithOwnerGoroutineCheck(enabled bool) Option {
+	return func(o *Options) {
+		o.ownerGoroutineCheck = enabled
+	}
+}
+
 // WithStrictOSThread enables strict OS-thread affinity checks.
 func WithStrictOSThread(enabled bool) Option {
 	return func(o *Options) {
@@ -223,6 +234,7 @@ func NewRuntime(opts ...Option) *Runtime {
 		canBlock:             true,
 		moduleImport:         false,
 		strip:                1,
+		ownerGoroutineCheck:  true,
 		strictThreadAffinity: false,
 	}
 	for _, opt := range opts {

--- a/runtime.go
+++ b/runtime.go
@@ -8,8 +8,6 @@ import "C"
 import (
 	"errors"
 	goruntime "runtime"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -39,6 +37,7 @@ var errOwnerAccessDenied = errors.New("quickjs: owner access denied; if strict O
 
 var ownerCheckCurrentGoroutineID = currentGoroutineID
 var ownerCheckCurrentThreadID = currentThreadID
+var goroutineStack = goruntime.Stack
 
 type classObjectIdentity struct {
 	contextID uint64
@@ -129,10 +128,30 @@ func (r *Runtime) claimOrVerifyOwnerThread(current uint64) bool {
 }
 
 func currentGoroutineID() uint64 {
-	var buf [64]byte
-	n := goruntime.Stack(buf[:], false)
-	fields := strings.Fields(string(buf[:n]))
-	id, _ := strconv.ParseUint(fields[1], 10, 64)
+	const prefix = "goroutine "
+
+	var buf [128]byte
+	n := goroutineStack(buf[:], false)
+	if n <= len(prefix) {
+		return 0
+	}
+
+	idx := len(prefix)
+	var id uint64
+	hasDigit := false
+	for idx < n {
+		c := buf[idx]
+		if c < '0' || c > '9' {
+			break
+		}
+		hasDigit = true
+		id = id*10 + uint64(c-'0')
+		idx++
+	}
+
+	if !hasDigit {
+		return 0
+	}
 	return id
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -6,7 +6,10 @@ package quickjs
 */
 import "C"
 import (
+	"errors"
 	goruntime "runtime"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"unsafe"
@@ -32,6 +35,11 @@ var runtimeInitContextHook func(ctx *C.JSContext) C.JSValue
 // It must remain nil in production.
 var runtimeEvalFunctionHook func(ctx *C.JSContext, compiled C.JSValue) C.JSValue
 
+var errOwnerAccessDenied = errors.New("quickjs: owner access denied; if strict OS thread mode is enabled, bind the owner goroutine with runtime.LockOSThread()")
+
+var ownerCheckCurrentGoroutineID = currentGoroutineID
+var ownerCheckCurrentThreadID = currentThreadID
+
 type classObjectIdentity struct {
 	contextID uint64
 	handleID  int32
@@ -42,6 +50,8 @@ type Runtime struct {
 	mu                     sync.RWMutex
 	ref                    *C.JSRuntime
 	options                *Options
+	ownerGoroutineID       atomic.Uint64
+	ownerThreadID          atomic.Uint64
 	interruptHandlerState  atomic.Pointer[interruptHandlerHolder]
 	contexts               sync.Map
 	contextsByID           sync.Map
@@ -62,16 +72,73 @@ func (r *Runtime) isAlive() bool {
 }
 
 type Options struct {
-	timeout      uint64
-	memoryLimit  uint64
-	gcThreshold  int64
-	maxStackSize uint64
-	canBlock     bool
-	moduleImport bool
-	strip        int
+	timeout              uint64
+	memoryLimit          uint64
+	gcThreshold          int64
+	maxStackSize         uint64
+	canBlock             bool
+	moduleImport         bool
+	strip                int
+	strictThreadAffinity bool
 }
 
 type Option func(*Options)
+
+func (r *Runtime) ensureOwnerAccess() bool {
+	if r == nil {
+		return false
+	}
+
+	gid := ownerCheckCurrentGoroutineID()
+	if gid == 0 {
+		return false
+	}
+	if !r.claimOrVerifyOwnerGoroutine(gid) {
+		return false
+	}
+
+	if r.options != nil && r.options.strictThreadAffinity {
+		tid := ownerCheckCurrentThreadID()
+		if tid == 0 {
+			return false
+		}
+		if !r.claimOrVerifyOwnerThread(tid) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *Runtime) claimOrVerifyOwnerGoroutine(current uint64) bool {
+	owner := r.ownerGoroutineID.Load()
+	if owner == 0 {
+		r.ownerGoroutineID.CompareAndSwap(0, current)
+		owner = r.ownerGoroutineID.Load()
+	}
+	return owner == current
+}
+
+func (r *Runtime) claimOrVerifyOwnerThread(current uint64) bool {
+	owner := r.ownerThreadID.Load()
+	if owner == 0 {
+		r.ownerThreadID.CompareAndSwap(0, current)
+		owner = r.ownerThreadID.Load()
+	}
+	return owner == current
+}
+
+func currentGoroutineID() uint64 {
+	var buf [64]byte
+	n := goruntime.Stack(buf[:], false)
+	fields := strings.Fields(string(buf[:n]))
+	id, _ := strconv.ParseUint(fields[1], 10, 64)
+	return id
+}
+
+func currentThreadID() uint64 {
+	return uint64(C.CurrentThreadID())
+}
 
 // WithExecuteTimeout will set the runtime's execute timeout; default is 0
 func WithExecuteTimeout(timeout uint64) Option {
@@ -120,16 +187,24 @@ func WithStripInfo(strip int) Option {
 	}
 }
 
+// WithStrictOSThread enables strict OS-thread affinity checks.
+func WithStrictOSThread(enabled bool) Option {
+	return func(o *Options) {
+		o.strictThreadAffinity = enabled
+	}
+}
+
 // NewRuntime creates a new quickjs runtime with simplified interrupt handling.
 func NewRuntime(opts ...Option) *Runtime {
 	options := &Options{
-		timeout:      0,
-		memoryLimit:  0,
-		gcThreshold:  -1,
-		maxStackSize: 0,
-		canBlock:     true,
-		moduleImport: false,
-		strip:        1,
+		timeout:              0,
+		memoryLimit:          0,
+		gcThreshold:          -1,
+		maxStackSize:         0,
+		canBlock:             true,
+		moduleImport:         false,
+		strip:                1,
+		strictThreadAffinity: false,
 	}
 	for _, opt := range opts {
 		opt(options)
@@ -178,6 +253,9 @@ func (r *Runtime) RunGC() {
 	if r == nil {
 		return
 	}
+	if !r.ensureOwnerAccess() {
+		return
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if r.closed.Load() || r.ref == nil {
@@ -203,6 +281,9 @@ func GetAwaitPollSliceMs() int {
 // Close will free the runtime pointer with proper cleanup.
 func (r *Runtime) Close() {
 	if r == nil {
+		return
+	}
+	if !r.ensureOwnerAccess() {
 		return
 	}
 
@@ -265,6 +346,9 @@ func (r *Runtime) SetCanBlock(canBlock bool) {
 	if r == nil {
 		return
 	}
+	if !r.ensureOwnerAccess() {
+		return
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if r.closed.Load() || r.ref == nil {
@@ -277,6 +361,9 @@ func (r *Runtime) SetCanBlock(canBlock bool) {
 // SetMemoryLimit the runtime memory limit; if not set, it will be unlimit.
 func (r *Runtime) SetMemoryLimit(limit uint64) {
 	if r == nil {
+		return
+	}
+	if !r.ensureOwnerAccess() {
 		return
 	}
 	r.mu.RLock()
@@ -292,6 +379,9 @@ func (r *Runtime) SetGCThreshold(threshold int64) {
 	if r == nil {
 		return
 	}
+	if !r.ensureOwnerAccess() {
+		return
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if r.closed.Load() || r.ref == nil {
@@ -303,6 +393,9 @@ func (r *Runtime) SetGCThreshold(threshold int64) {
 // SetMaxStackSize will set max runtime's stack size;
 func (r *Runtime) SetMaxStackSize(stack_size uint64) {
 	if r == nil {
+		return
+	}
+	if !r.ensureOwnerAccess() {
 		return
 	}
 	r.mu.RLock()
@@ -317,6 +410,9 @@ func (r *Runtime) SetMaxStackSize(stack_size uint64) {
 // This will override any user interrupt handler (expected behavior)
 func (r *Runtime) SetExecuteTimeout(timeout uint64) {
 	if r == nil {
+		return
+	}
+	if !r.ensureOwnerAccess() {
 		return
 	}
 	r.mu.Lock()
@@ -334,6 +430,9 @@ func (r *Runtime) SetStripInfo(strip int) {
 	if r == nil {
 		return
 	}
+	if !r.ensureOwnerAccess() {
+		return
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if r.closed.Load() || r.ref == nil {
@@ -348,6 +447,9 @@ func (r *Runtime) SetModuleImport(moduleImport bool) {
 	if r == nil {
 		return
 	}
+	if !r.ensureOwnerAccess() {
+		return
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if r.closed.Load() || r.ref == nil {
@@ -360,6 +462,9 @@ func (r *Runtime) SetModuleImport(moduleImport bool) {
 // This will override any timeout handler (expected behavior)
 func (r *Runtime) SetInterruptHandler(handler InterruptHandler) {
 	if r == nil {
+		return
+	}
+	if !r.ensureOwnerAccess() {
 		return
 	}
 	r.mu.Lock()
@@ -386,6 +491,9 @@ func (r *Runtime) ClearInterruptHandler() {
 	if r == nil {
 		return
 	}
+	if !r.ensureOwnerAccess() {
+		return
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.ref == nil {
@@ -410,6 +518,9 @@ func (r *Runtime) callInterruptHandler() int {
 // NewContext creates a new JavaScript context.
 func (r *Runtime) NewContext() *Context {
 	if r == nil {
+		return nil
+	}
+	if !r.ensureOwnerAccess() {
 		return nil
 	}
 

--- a/runtime.go
+++ b/runtime.go
@@ -33,7 +33,7 @@ var runtimeInitContextHook func(ctx *C.JSContext) C.JSValue
 // It must remain nil in production.
 var runtimeEvalFunctionHook func(ctx *C.JSContext, compiled C.JSValue) C.JSValue
 
-var errOwnerAccessDenied = errors.New("quickjs: owner access denied; if strict OS thread mode is enabled, bind the owner goroutine with runtime.LockOSThread()")
+var errOwnerAccessDenied = errors.New("quickjs: owner access denied; runtime/context/value APIs must be called from the owner goroutine; if strict OS thread mode is enabled, also bind that goroutine with runtime.LockOSThread()")
 
 var ownerCheckCurrentGoroutineID = currentGoroutineID
 var ownerCheckCurrentThreadID = currentThreadID

--- a/runtime.go
+++ b/runtime.go
@@ -115,7 +115,9 @@ func (r *Runtime) ensureOwnerAccess() bool {
 func (r *Runtime) claimOrVerifyOwnerGoroutine(current uint64) bool {
 	owner := r.ownerGoroutineID.Load()
 	if owner == 0 {
-		r.ownerGoroutineID.CompareAndSwap(0, current)
+		if r.ownerGoroutineID.CompareAndSwap(0, current) {
+			return true
+		}
 		owner = r.ownerGoroutineID.Load()
 	}
 	return owner == current

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1106,6 +1106,34 @@ func TestRuntimeOwnerCheckHooksAndStrictThreadAffinity(t *testing.T) {
 	rtNoCheck.Close()
 }
 
+func TestCurrentGoroutineIDFailClosedParser(t *testing.T) {
+	oldStack := goroutineStack
+	defer func() {
+		goroutineStack = oldStack
+	}()
+
+	goroutineStack = func(buf []byte, all bool) int {
+		const s = "goroutine "
+		copy(buf, s)
+		return len(s)
+	}
+	require.Zero(t, currentGoroutineID())
+
+	goroutineStack = func(buf []byte, all bool) int {
+		const s = "goroutine x [running]:\n"
+		copy(buf, s)
+		return len(s)
+	}
+	require.Zero(t, currentGoroutineID())
+
+	goroutineStack = func(buf []byte, all bool) int {
+		const s = "goroutine 424242 [running]:\n"
+		copy(buf, s)
+		return len(s)
+	}
+	require.Equal(t, uint64(424242), currentGoroutineID())
+}
+
 func TestRuntimeOwnerCheckGatesRuntimeContextAndValuePaths(t *testing.T) {
 	oldGIDHook := ownerCheckCurrentGoroutineID
 	oldThreadHook := ownerCheckCurrentThreadID

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1106,6 +1106,52 @@ func TestRuntimeOwnerCheckHooksAndStrictThreadAffinity(t *testing.T) {
 	rtNoCheck.Close()
 }
 
+func TestRuntimeOwnerGoroutineCheckOption(t *testing.T) {
+	oldGIDHook := ownerCheckCurrentGoroutineID
+	oldThreadHook := ownerCheckCurrentThreadID
+	defer func() {
+		ownerCheckCurrentGoroutineID = oldGIDHook
+		ownerCheckCurrentThreadID = oldThreadHook
+	}()
+
+	var gid atomic.Uint64
+	var tid atomic.Uint64
+	gid.Store(31)
+	tid.Store(1)
+
+	ownerCheckCurrentGoroutineID = func() uint64 { return gid.Load() }
+	ownerCheckCurrentThreadID = func() uint64 { return tid.Load() }
+
+	defaultRT := NewRuntime()
+	require.NotNil(t, defaultRT)
+	require.True(t, defaultRT.options.ownerGoroutineCheck)
+	require.True(t, defaultRT.ensureOwnerAccess())
+	gid.Store(32)
+	require.False(t, defaultRT.ensureOwnerAccess())
+	gid.Store(31)
+	defaultRT.Close()
+
+	unsafeRT := NewRuntime(WithOwnerGoroutineCheck(false))
+	require.NotNil(t, unsafeRT)
+	require.False(t, unsafeRT.options.ownerGoroutineCheck)
+	require.True(t, unsafeRT.ensureOwnerAccess())
+	gid.Store(33)
+	require.True(t, unsafeRT.ensureOwnerAccess())
+	ctx := unsafeRT.NewContext()
+	require.NotNil(t, ctx)
+	ctx.Close()
+	unsafeRT.Close()
+
+	unsafeStrictRT := NewRuntime(WithOwnerGoroutineCheck(false), WithStrictOSThread(true))
+	require.NotNil(t, unsafeStrictRT)
+	require.True(t, unsafeStrictRT.ensureOwnerAccess())
+	tid.Store(2)
+	require.False(t, unsafeStrictRT.ensureOwnerAccess())
+	tid.Store(1)
+	require.True(t, unsafeStrictRT.ensureOwnerAccess())
+	unsafeStrictRT.Close()
+}
+
 func TestCurrentGoroutineIDFailClosedParser(t *testing.T) {
 	oldStack := goroutineStack
 	defer func() {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1,8 +1,10 @@
 package quickjs
 
 import (
+	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -150,6 +152,8 @@ func TestAwaitPollSliceMsConfig(t *testing.T) {
 
 // TestRuntimeInterruptHandler tests interrupt handler functionality and coverage
 func TestRuntimeInterruptHandler(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 
@@ -468,6 +472,63 @@ func TestRuntimeRegisterClassObjectIdentityCorruptedBucketRepairedBeforeLock(t *
 	require.True(t, exists)
 }
 
+func TestRuntimeRegisterClassObjectIdentityCorruptionBranchesDeterministic(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	// Normal typed-bucket path.
+	normalID := rt.registerClassObjectIdentity(ctx.contextID, 1)
+	require.NotZero(t, normalID)
+
+	// Corruption replacement path.
+	rt.classObjectIDsByCtx.Store(ctx.contextID, "corrupted-bucket")
+	replacementID := rt.registerClassObjectIdentity(ctx.contextID, 2)
+	require.NotZero(t, replacementID)
+	bucketValue, ok := rt.classObjectIDsByCtx.Load(ctx.contextID)
+	require.True(t, ok)
+	_, typed := bucketValue.(*sync.Map)
+	require.True(t, typed)
+
+	// Corruption repaired-before-lock path (existing typed bucket reused).
+	rt.classObjectIDsByCtx.Store(ctx.contextID, "corrupted-bucket-again")
+	repairedBucket := &sync.Map{}
+
+	rt.mu.Lock()
+	resultCh := make(chan int32, 1)
+	go func() {
+		resultCh <- rt.registerClassObjectIdentity(ctx.contextID, 3)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		found := false
+		rt.classObjectRegistry.Range(func(_, value interface{}) bool {
+			identity, ok := value.(classObjectIdentity)
+			if ok && identity.handleID == 3 {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for registerClassObjectIdentity pre-lock state")
+		}
+	}
+
+	rt.classObjectIDsByCtx.Store(ctx.contextID, repairedBucket)
+	rt.mu.Unlock()
+
+	repairedID := <-resultCh
+	require.NotZero(t, repairedID)
+	_, exists := repairedBucket.Load(repairedID)
+	require.True(t, exists)
+}
+
 func TestRuntimeIdentityRegistryCorruptionFailClosed(t *testing.T) {
 	rt := NewRuntime()
 	defer rt.Close()
@@ -760,35 +821,34 @@ func TestRuntimeTimeoutOpaqueConcurrentLifecycle(t *testing.T) {
 
 func TestRuntimeCrossGoroutineLifecycleWithoutInternalThreadBinding(t *testing.T) {
 	created := make(chan *Runtime, 1)
+	ownerClosed := make(chan struct{})
+	closeRequested := make(chan struct{})
 
 	go func() {
 		rt := NewRuntime()
 		created <- rt
+		<-closeRequested
+		rt.Close()
+		close(ownerClosed)
 	}()
 
 	rt := <-created
 	require.NotNil(t, rt)
 
-	ctx := rt.NewContext()
-	require.NotNil(t, ctx)
+	// Cross-goroutine access is rejected by owner contract.
+	require.Nil(t, rt.NewContext())
 
-	result := ctx.Eval(`1 + 2`)
-	require.NotNil(t, result)
-	require.False(t, result.IsException())
-	require.EqualValues(t, 3, result.ToInt32())
-	result.Free()
+	// Non-owner close is fail-closed no-op; owner goroutine must close it.
+	rt.Close()
+	require.NotNil(t, rt.ref)
 
-	closed := make(chan struct{})
-	go func() {
-		ctx.Close()
-		rt.Close()
-		close(closed)
-	}()
+	close(closeRequested)
 
 	select {
-	case <-closed:
+	case <-ownerClosed:
+		require.Nil(t, rt.ref)
 	case <-time.After(2 * time.Second):
-		t.Fatal("cross-goroutine close blocked")
+		t.Fatal("owner goroutine close blocked")
 	}
 }
 
@@ -993,4 +1053,241 @@ func TestInitializeContextGlobalsFailurePaths(t *testing.T) {
 
 		require.True(t, initializeContextGlobals(ctx.ref, "globalThis.__initProbeDisabled = 1", "hook-success-disable.js"))
 	})
+}
+
+func TestRuntimeOwnerCheckHooksAndStrictThreadAffinity(t *testing.T) {
+	oldGIDHook := ownerCheckCurrentGoroutineID
+	oldThreadHook := ownerCheckCurrentThreadID
+	defer func() {
+		ownerCheckCurrentGoroutineID = oldGIDHook
+		ownerCheckCurrentThreadID = oldThreadHook
+	}()
+
+	var gid atomic.Uint64
+	var tid atomic.Uint64
+	gid.Store(11)
+	tid.Store(101)
+
+	ownerCheckCurrentGoroutineID = func() uint64 { return gid.Load() }
+	ownerCheckCurrentThreadID = func() uint64 { return tid.Load() }
+
+	var nilRuntime *Runtime
+	require.False(t, nilRuntime.ensureOwnerAccess())
+
+	rt := NewRuntime(WithStrictOSThread(true))
+	require.NotNil(t, rt)
+	defer rt.Close()
+
+	require.True(t, rt.ensureOwnerAccess())
+	require.Equal(t, uint64(11), rt.ownerGoroutineID.Load())
+	require.Equal(t, uint64(101), rt.ownerThreadID.Load())
+	require.NotZero(t, currentGoroutineID())
+	require.NotZero(t, currentThreadID())
+
+	gid.Store(0)
+	require.False(t, rt.ensureOwnerAccess())
+	gid.Store(11)
+	tid.Store(0)
+	require.False(t, rt.ensureOwnerAccess())
+	tid.Store(101)
+
+	gid.Store(12)
+	require.False(t, rt.ensureOwnerAccess())
+
+	gid.Store(11)
+	tid.Store(102)
+	require.False(t, rt.ensureOwnerAccess())
+
+	tid.Store(101)
+	require.True(t, rt.ensureOwnerAccess())
+
+	rtNoCheck := NewRuntime()
+	require.True(t, rtNoCheck.ensureOwnerAccess())
+	rtNoCheck.Close()
+}
+
+func TestRuntimeOwnerCheckGatesRuntimeContextAndValuePaths(t *testing.T) {
+	oldGIDHook := ownerCheckCurrentGoroutineID
+	oldThreadHook := ownerCheckCurrentThreadID
+	defer func() {
+		ownerCheckCurrentGoroutineID = oldGIDHook
+		ownerCheckCurrentThreadID = oldThreadHook
+	}()
+
+	var gid atomic.Uint64
+	gid.Store(21)
+	ownerCheckCurrentGoroutineID = func() uint64 { return gid.Load() }
+	ownerCheckCurrentThreadID = func() uint64 { return 1 }
+
+	rt := NewRuntime()
+	require.NotNil(t, rt)
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+	defer ctx.Close()
+	defer rt.Close()
+
+	obj := ctx.Eval(`({ x: 1, inc: function(){ return this.x + 1; } })`)
+	require.NotNil(t, obj)
+	require.False(t, obj.IsException())
+	defer obj.Free()
+
+	throwVal := ctx.ThrowError(errors.New("owner-check-path"))
+	require.NotNil(t, throwVal)
+	require.True(t, throwVal.IsException())
+	throwVal.Free()
+
+	incFn := obj.Get("inc")
+	require.NotNil(t, incFn)
+	defer incFn.Free()
+
+	ctor := ctx.Eval(`(function C(){ this.v = 1; })`)
+	require.NotNil(t, ctor)
+	require.False(t, ctor.IsException())
+	defer ctor.Free()
+
+	val := ctx.NewInt32(9)
+	require.NotNil(t, val)
+	defer val.Free()
+	val1 := ctx.NewInt32(1)
+	defer val1.Free()
+	val2 := ctx.NewInt32(2)
+	defer val2.Free()
+
+	adderObj := ctx.Eval(`({ add: function(a, b){ return a + b; } })`)
+	require.NotNil(t, adderObj)
+	require.False(t, adderObj.IsException())
+	defer adderObj.Free()
+
+	adderFn := ctx.Eval(`(function(a, b){ return a + b; })`)
+	require.NotNil(t, adderFn)
+	require.False(t, adderFn.IsException())
+	defer adderFn.Free()
+	thisVal := ctx.NewUndefined()
+	defer thisVal.Free()
+
+	ctorWithArg := ctx.Eval(`(function D(v){ this.v = v; })`)
+	require.NotNil(t, ctorWithArg)
+	require.False(t, ctorWithArg.IsException())
+	defer ctorWithArg.Free()
+
+	ctxOther := rt.NewContext()
+	require.NotNil(t, ctxOther)
+	defer ctxOther.Close()
+	otherVal := ctxOther.NewInt32(99)
+	defer otherVal.Free()
+
+	gid.Store(22)
+
+	require.Nil(t, rt.NewContext())
+	rt.RunGC()
+	rt.SetMemoryLimit(1024)
+	rt.SetGCThreshold(2048)
+	rt.SetMaxStackSize(4096)
+	rt.SetCanBlock(true)
+	rt.SetStripInfo(1)
+	rt.SetModuleImport(true)
+	rt.SetExecuteTimeout(1)
+	rt.SetInterruptHandler(func() int { return 1 })
+	rt.ClearInterruptHandler()
+
+	require.Nil(t, ctx.Eval("1 + 1"))
+	_, err := ctx.Compile("1 + 1")
+	require.ErrorIs(t, err, errOwnerAccessDenied)
+	require.Nil(t, ctx.LoadModuleBytecode([]byte{1, 2, 3}))
+	require.Nil(t, ctx.EvalBytecode([]byte{1, 2, 3}))
+	require.Nil(t, ctx.Globals())
+	require.Nil(t, ctx.ThrowSyntaxError("x"))
+	require.Nil(t, ctx.ThrowTypeError("x"))
+	require.Nil(t, ctx.ThrowReferenceError("x"))
+	require.Nil(t, ctx.ThrowRangeError("x"))
+	require.Nil(t, ctx.ThrowInternalError("x"))
+	require.Nil(t, ctx.ThrowError(errors.New("x")))
+	require.Nil(t, ctx.Throw(val))
+	require.Nil(t, ctx.NewPromise(func(resolve, reject func(*Value)) {}))
+	require.Nil(t, ctx.Await(nil))
+	require.False(t, ctx.HasException())
+	require.Nil(t, ctx.Exception())
+	require.NotPanics(t, func() { ctx.Loop() })
+
+	obj.Set("x", val)
+	obj.SetIdx(0, val)
+	require.Nil(t, obj.Get("x"))
+	require.Nil(t, obj.GetIdx(0))
+	require.Nil(t, obj.Call("inc"))
+	require.Nil(t, adderObj.Call("add", val1, val2))
+	require.Nil(t, incFn.Execute(obj))
+	require.Nil(t, adderFn.Execute(thisVal, val1, val2))
+	require.Nil(t, adderFn.Execute(thisVal, otherVal))
+	require.Nil(t, ctor.CallConstructor())
+	require.Nil(t, ctorWithArg.CallConstructor(val1))
+	_, err = obj.GetGoObject()
+	require.ErrorIs(t, err, errOwnerAccessDenied)
+
+	gid.Store(21)
+	rtClose := NewRuntime()
+	ctxClose := rtClose.NewContext()
+	require.NotNil(t, ctxClose)
+	gid.Store(22)
+	rtClose.Close()
+	require.NotNil(t, rtClose.ref)
+	gid.Store(21)
+	ctxClose.Close()
+	rtClose.Close()
+	require.Nil(t, rtClose.ref)
+
+	gid.Store(21)
+
+	extraCtx := rt.NewContext()
+	require.NotNil(t, extraCtx)
+	extraCtx.Close()
+	result := ctx.Eval("1 + 1")
+	require.NotNil(t, result)
+	require.False(t, result.IsException())
+	require.EqualValues(t, 2, result.ToInt32())
+	result.Free()
+
+	next := obj.Call("inc")
+	require.NotNil(t, next)
+	require.False(t, next.IsException())
+	require.EqualValues(t, 2, next.ToInt32())
+	next.Free()
+
+	emptyNameCall := obj.Call("")
+	require.NotNil(t, emptyNameCall)
+	emptyNameCall.Free()
+
+	addResult := adderObj.Call("add", val1, val2)
+	require.NotNil(t, addResult)
+	require.False(t, addResult.IsException())
+	require.EqualValues(t, 3, addResult.ToInt32())
+	addResult.Free()
+	require.Nil(t, adderObj.Call("add", otherVal))
+
+	execResult := adderFn.Execute(thisVal, val1, val2)
+	require.NotNil(t, execResult)
+	require.False(t, execResult.IsException())
+	require.EqualValues(t, 3, execResult.ToInt32())
+	execResult.Free()
+	require.Nil(t, adderFn.Execute(thisVal, otherVal))
+	require.Nil(t, adderFn.Execute(otherVal, val1))
+
+	execZeroArg := incFn.Execute(obj)
+	require.NotNil(t, execZeroArg)
+	require.False(t, execZeroArg.IsException())
+	require.EqualValues(t, 2, execZeroArg.ToInt32())
+	execZeroArg.Free()
+
+	instanceNoArg := ctor.CallConstructor()
+	require.NotNil(t, instanceNoArg)
+	instanceNoArg.Free()
+
+	instance := ctorWithArg.CallConstructor(val1)
+	require.NotNil(t, instance)
+	require.False(t, instance.IsException())
+	require.Nil(t, ctorWithArg.CallConstructor(otherVal))
+	got := instance.Get("v")
+	require.NotNil(t, got)
+	require.EqualValues(t, 1, got.ToInt32())
+	got.Free()
+	instance.Free()
 }

--- a/value.go
+++ b/value.go
@@ -25,9 +25,13 @@ func (v *Value) hasValidContext() bool {
 	return v != nil && v.ctx != nil && v.ctx.hasValidRef()
 }
 
+func sameContextRef(a *Value, b *Value) bool {
+	return a != nil && b != nil && a.ctx != nil && b.ctx != nil && a.ctx == b.ctx
+}
+
 // sameContext reports whether two values belong to the same live context.
 func sameContext(a *Value, b *Value) bool {
-	return a != nil && b != nil && a.ctx != nil && b.ctx != nil && a.ctx == b.ctx && a.hasValidContext() && b.hasValidContext()
+	return sameContextRef(a, b) && a.ctx.hasValidRef()
 }
 
 // Free the value.
@@ -167,7 +171,7 @@ func (v *Value) ByteLen() int64 {
 
 // Set sets the value of the property with the given name.
 func (v *Value) Set(name string, val *Value) {
-	if !v.hasValidContext() || !sameContext(v, val) {
+	if !v.hasValidContext() || !sameContextRef(v, val) {
 		return
 	}
 	var namePtr *C.char
@@ -179,7 +183,7 @@ func (v *Value) Set(name string, val *Value) {
 
 // SetIdx sets the value of the property with the given index.
 func (v *Value) SetIdx(idx int64, val *Value) {
-	if !v.hasValidContext() || !sameContext(v, val) {
+	if !v.hasValidContext() || !sameContextRef(v, val) {
 		return
 	}
 	C.JS_SetPropertyUint32(v.ctx.ref, v.ref, C.uint32_t(idx), val.ref)
@@ -216,7 +220,7 @@ func (v *Value) Call(fname string, args ...*Value) *Value {
 	}
 	cargs := []C.JSValue{}
 	for _, x := range args {
-		if !sameContext(v, x) {
+		if !sameContextRef(v, x) {
 			return nil
 		}
 		cargs = append(cargs, x.ref)
@@ -233,12 +237,12 @@ func (v *Value) Call(fname string, args ...*Value) *Value {
 
 // Execute the function with the given arguments.
 func (v *Value) Execute(this *Value, args ...*Value) *Value {
-	if !v.hasValidContext() || !sameContext(v, this) {
+	if !v.hasValidContext() || !sameContextRef(v, this) {
 		return nil
 	}
 	cargs := []C.JSValue{}
 	for _, x := range args {
-		if !sameContext(v, x) {
+		if !sameContextRef(v, x) {
 			return nil
 		}
 		cargs = append(cargs, x.ref)
@@ -276,7 +280,7 @@ func (v *Value) CallConstructor(args ...*Value) *Value {
 	}
 	cargs := []C.JSValue{}
 	for _, x := range args {
-		if !sameContext(v, x) {
+		if !sameContextRef(v, x) {
 			return nil
 		}
 		cargs = append(cargs, x.ref)

--- a/value.go
+++ b/value.go
@@ -22,12 +22,12 @@ type Value struct {
 
 // hasValidContext reports whether a Value still has a usable context pointer.
 func (v *Value) hasValidContext() bool {
-	return v != nil && v.ctx != nil && v.ctx.ref != nil
+	return v != nil && v.ctx != nil && v.ctx.hasValidRef()
 }
 
 // sameContext reports whether two values belong to the same live context.
 func sameContext(a *Value, b *Value) bool {
-	return a != nil && b != nil && a.ctx != nil && b.ctx != nil && a.ctx == b.ctx && a.ctx.ref != nil && b.ctx.ref != nil
+	return a != nil && b != nil && a.ctx != nil && b.ctx != nil && a.ctx == b.ctx && a.hasValidContext() && b.hasValidContext()
 }
 
 // Free the value.
@@ -167,6 +167,9 @@ func (v *Value) ByteLen() int64 {
 
 // Set sets the value of the property with the given name.
 func (v *Value) Set(name string, val *Value) {
+	if !v.hasValidContext() || !sameContext(v, val) {
+		return
+	}
 	var namePtr *C.char
 	if len(name) > 0 {
 		namePtr = (*C.char)(unsafe.Pointer(unsafe.StringData(name)))
@@ -176,11 +179,17 @@ func (v *Value) Set(name string, val *Value) {
 
 // SetIdx sets the value of the property with the given index.
 func (v *Value) SetIdx(idx int64, val *Value) {
+	if !v.hasValidContext() || !sameContext(v, val) {
+		return
+	}
 	C.JS_SetPropertyUint32(v.ctx.ref, v.ref, C.uint32_t(idx), val.ref)
 }
 
 // Get returns the value of the property with the given name.
 func (v *Value) Get(name string) *Value {
+	if !v.hasValidContext() {
+		return nil
+	}
 	var namePtr *C.char
 	if len(name) > 0 {
 		namePtr = (*C.char)(unsafe.Pointer(unsafe.StringData(name)))
@@ -190,17 +199,26 @@ func (v *Value) Get(name string) *Value {
 
 // GetIdx returns the value of the property with the given index.
 func (v *Value) GetIdx(idx int64) *Value {
+	if !v.hasValidContext() {
+		return nil
+	}
 	return &Value{ctx: v.ctx, ref: C.JS_GetPropertyUint32(v.ctx.ref, v.ref, C.uint32_t(idx))}
 }
 
 // Call calls the function with the given arguments.
 func (v *Value) Call(fname string, args ...*Value) *Value {
+	if !v.hasValidContext() {
+		return nil
+	}
 	var fnamePtr *C.char
 	if len(fname) > 0 {
 		fnamePtr = (*C.char)(unsafe.Pointer(unsafe.StringData(fname)))
 	}
 	cargs := []C.JSValue{}
 	for _, x := range args {
+		if !sameContext(v, x) {
+			return nil
+		}
 		cargs = append(cargs, x.ref)
 	}
 	var ref C.JSValue
@@ -215,8 +233,14 @@ func (v *Value) Call(fname string, args ...*Value) *Value {
 
 // Execute the function with the given arguments.
 func (v *Value) Execute(this *Value, args ...*Value) *Value {
+	if !v.hasValidContext() || !sameContext(v, this) {
+		return nil
+	}
 	cargs := []C.JSValue{}
 	for _, x := range args {
+		if !sameContext(v, x) {
+			return nil
+		}
 		cargs = append(cargs, x.ref)
 	}
 	var val *Value
@@ -247,8 +271,14 @@ func (v *Value) New(args ...*Value) *Value {
 // This replaces the previous NewInstance method and provides automatic property binding
 // and simplified constructor semantics where constructors work with pre-created instances.
 func (v *Value) CallConstructor(args ...*Value) *Value {
+	if !v.hasValidContext() {
+		return nil
+	}
 	cargs := []C.JSValue{}
 	for _, x := range args {
+		if !sameContext(v, x) {
+			return nil
+		}
 		cargs = append(cargs, x.ref)
 	}
 	var val *Value
@@ -743,7 +773,13 @@ func (v *Value) GetClassID() uint32 {
 // GetGoObject retrieves Go object from JavaScript class instance
 // This method extracts the opaque data stored by the constructor proxy
 func (v *Value) GetGoObject() (interface{}, error) {
-	if !v.hasValidContext() || v.ctx.handleStore == nil {
+	if v == nil || v.ctx == nil {
+		return nil, errors.New("value context is not available")
+	}
+	if v.ctx.runtime == nil || !v.ctx.runtime.ensureOwnerAccess() {
+		return nil, errOwnerAccessDenied
+	}
+	if v.ctx.ref == nil || v.ctx.handleStore == nil {
 		return nil, errors.New("value context is not available")
 	}
 

--- a/value_test.go
+++ b/value_test.go
@@ -15,6 +15,8 @@ type Point struct {
 
 // TestValueBasics tests basic value creation and type checking
 func TestValueBasics(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -60,6 +62,8 @@ func TestValueBasics(t *testing.T) {
 
 // TestValueConversions tests type conversions including deprecated methods
 func TestValueConversions(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -138,6 +142,8 @@ func TestValueConversions(t *testing.T) {
 
 // TestValueJSON tests JSON operations
 func TestValueJSON(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -178,6 +184,8 @@ func TestValueJSON(t *testing.T) {
 
 // TestValueArrayBuffer tests ArrayBuffer operations
 func TestValueArrayBuffer(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -232,6 +240,8 @@ func TestValueArrayBuffer(t *testing.T) {
 
 // TestValueTypedArrays tests TypedArray detection and conversion
 func TestValueTypedArrays(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -394,6 +404,8 @@ func TestValueTypedArrays(t *testing.T) {
 
 // TestValueProperties tests property operations
 func TestValueProperties(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -448,6 +460,8 @@ func TestValueProperties(t *testing.T) {
 
 // TestValueFunctionCalls tests function calls and constructors
 func TestValueFunctionCalls(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -509,6 +523,8 @@ func TestValueFunctionCalls(t *testing.T) {
 
 // TestValueError tests error handling
 func TestValueError(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -559,6 +575,8 @@ func TestValueError(t *testing.T) {
 
 // TestValueInstanceof tests instanceof operations
 func TestValueInstanceof(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -601,6 +619,8 @@ func TestValueInstanceof(t *testing.T) {
 
 // TestValueSpecialTypes tests special types and edge cases
 func TestValueSpecialTypes(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -687,6 +707,8 @@ func TestValueSpecialTypes(t *testing.T) {
 
 // TestPromiseState tests promise state handling
 func TestPromiseState(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -723,6 +745,8 @@ func TestPromiseState(t *testing.T) {
 
 // TestValueAwait tests promise await functionality
 func TestValueAwait(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -766,6 +790,8 @@ func TestValueAwait(t *testing.T) {
 
 // TestValueClassInstanceEdgeCases tests uncovered branches in class instance methods
 func TestValueClassInstanceEdgeCases(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1024,6 +1050,8 @@ func TestValueHasInstanceDataFailClosedOnMissingOwnerContext(t *testing.T) {
 // TestValueCallConstructorEdgeCases tests edge cases and error conditions in CallConstructor
 // MODIFIED FOR SCHEME C: Removed all NewInstance tests, enhanced CallConstructor coverage
 func TestValueCallConstructorEdgeCases(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -1291,6 +1319,8 @@ func TestValueCallConstructorEdgeCases(t *testing.T) {
 // TestValueCallConstructorComprehensive tests comprehensive CallConstructor scenarios
 // NEW TEST: Comprehensive coverage for CallConstructor API
 func TestValueCallConstructorComprehensive(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()


### PR DESCRIPTION
- enforce owner access checks across Runtime, Context, and Value paths

- add strict OS-thread validation support and C bridge thread-id helper

- update English and Chinese README concurrency/lifecycle guidance

- remove dependency on global owner-check test defaults by migrating legacy tests to owner-safe patterns

- align runtime cross-goroutine tests with fail-closed ownership semantics