### PR TITLE
feat: add Value comparison and object-control APIs

### DIFF
--- a/value.go
+++ b/value.go
@@ -483,7 +483,11 @@ func (v *Value) IsExtensible() bool {
 	if !v.isAlive() {
 		return false
 	}
-	return C.JS_IsExtensible(v.ctx.ref, v.ref) == 1
+	ret := C.JS_IsExtensible(v.ctx.ref, v.ref)
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
 }
 
 // PreventExtensions marks object as non-extensible.
@@ -491,7 +495,11 @@ func (v *Value) PreventExtensions() bool {
 	if !v.isAlive() {
 		return false
 	}
-	return C.JS_PreventExtensions(v.ctx.ref, v.ref) == 1
+	ret := C.JS_PreventExtensions(v.ctx.ref, v.ref)
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
 }
 
 // Seal seals object properties and prevents extensions.
@@ -499,7 +507,11 @@ func (v *Value) Seal() bool {
 	if !v.isAlive() {
 		return false
 	}
-	return C.JS_SealObject(v.ctx.ref, v.ref) == 1
+	ret := C.JS_SealObject(v.ctx.ref, v.ref)
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
 }
 
 // Freeze freezes object properties and prevents extensions.
@@ -507,7 +519,11 @@ func (v *Value) Freeze() bool {
 	if !v.isAlive() {
 		return false
 	}
-	return C.JS_FreezeObject(v.ctx.ref, v.ref) == 1
+	ret := C.JS_FreezeObject(v.ctx.ref, v.ref)
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
 }
 
 // GlobalInstanceof checks if the value is an instance of the given global constructor

--- a/value.go
+++ b/value.go
@@ -50,6 +50,38 @@ func sameContext(a *Value, b *Value) bool {
 	return a.hasValidContext() && b.hasValidContext()
 }
 
+// Equal returns true if two values are abstractly equal (JS == semantics).
+func (v *Value) Equal(other *Value) bool {
+	if !sameContext(v, other) {
+		return false
+	}
+	return C.JS_IsEqual(v.ctx.ref, v.ref, other.ref) == 1
+}
+
+// StrictEqual returns true if two values are strictly equal (JS === semantics).
+func (v *Value) StrictEqual(other *Value) bool {
+	if !sameContext(v, other) {
+		return false
+	}
+	return bool(C.JS_IsStrictEqual(v.ctx.ref, v.ref, other.ref))
+}
+
+// SameValue returns true if two values are the same according to JS SameValue.
+func (v *Value) SameValue(other *Value) bool {
+	if !sameContext(v, other) {
+		return false
+	}
+	return bool(C.JS_IsSameValue(v.ctx.ref, v.ref, other.ref))
+}
+
+// SameValueZero returns true if two values are the same according to JS SameValueZero.
+func (v *Value) SameValueZero(other *Value) bool {
+	if !sameContext(v, other) {
+		return false
+	}
+	return bool(C.JS_IsSameValueZero(v.ctx.ref, v.ref, other.ref))
+}
+
 // Free the value.
 func (v *Value) Free() {
 	if !v.hasValidContext() || bool(C.JS_IsUndefined(v.ref)) {
@@ -428,6 +460,54 @@ func (v *Value) DeleteIdx(idx uint32) bool {
 		return false // Property does not exist, nothing to delete
 	}
 	return C.JS_DeletePropertyInt64(v.ctx.ref, v.ref, C.int64_t(idx), C.int(1)) == 1
+}
+
+// Prototype returns the object's prototype value.
+func (v *Value) Prototype() *Value {
+	if !v.isAlive() {
+		return nil
+	}
+	return &Value{ctx: v.ctx, ref: C.JS_GetPrototype(v.ctx.ref, v.ref)}
+}
+
+// SetPrototype sets the object's prototype.
+func (v *Value) SetPrototype(proto *Value) bool {
+	if !v.isAlive() || !proto.belongsTo(v.ctx) {
+		return false
+	}
+	return C.JS_SetPrototype(v.ctx.ref, v.ref, proto.ref) == 1
+}
+
+// IsExtensible returns true if new properties can still be added.
+func (v *Value) IsExtensible() bool {
+	if !v.isAlive() {
+		return false
+	}
+	return C.JS_IsExtensible(v.ctx.ref, v.ref) == 1
+}
+
+// PreventExtensions marks object as non-extensible.
+func (v *Value) PreventExtensions() bool {
+	if !v.isAlive() {
+		return false
+	}
+	return C.JS_PreventExtensions(v.ctx.ref, v.ref) == 1
+}
+
+// Seal seals object properties and prevents extensions.
+func (v *Value) Seal() bool {
+	if !v.isAlive() {
+		return false
+	}
+	return C.JS_SealObject(v.ctx.ref, v.ref) == 1
+}
+
+// Freeze freezes object properties and prevents extensions.
+func (v *Value) Freeze() bool {
+	if !v.isAlive() {
+		return false
+	}
+	return C.JS_FreezeObject(v.ctx.ref, v.ref) == 1
 }
 
 // GlobalInstanceof checks if the value is an instance of the given global constructor

--- a/value_test.go
+++ b/value_test.go
@@ -145,6 +145,43 @@ func TestValueObjectControlAPIs(t *testing.T) {
 	otherProto := ctx2.NewObject()
 	defer otherProto.Free()
 	require.False(t, obj.SetPrototype(otherProto))
+
+	// Hit explicit tri-state exception branches via Proxy traps that throw.
+	extensibleThrowProxy := ctx.Eval(`
+		new Proxy({}, {
+			isExtensible() { throw new Error('isExtensible trap error') }
+		})
+	`)
+	defer extensibleThrowProxy.Free()
+	require.False(t, extensibleThrowProxy.IsException())
+	require.False(t, extensibleThrowProxy.IsExtensible())
+
+	preventThrowProxy := ctx.Eval(`
+		new Proxy({}, {
+			preventExtensions() { throw new Error('preventExtensions trap error') }
+		})
+	`)
+	defer preventThrowProxy.Free()
+	require.False(t, preventThrowProxy.IsException())
+	require.False(t, preventThrowProxy.PreventExtensions())
+
+	sealThrowProxy := ctx.Eval(`
+		new Proxy({}, {
+			preventExtensions() { throw new Error('seal preventExtensions trap error') }
+		})
+	`)
+	defer sealThrowProxy.Free()
+	require.False(t, sealThrowProxy.IsException())
+	require.False(t, sealThrowProxy.Seal())
+
+	freezeThrowProxy := ctx.Eval(`
+		new Proxy({}, {
+			preventExtensions() { throw new Error('freeze preventExtensions trap error') }
+		})
+	`)
+	defer freezeThrowProxy.Free()
+	require.False(t, freezeThrowProxy.IsException())
+	require.False(t, freezeThrowProxy.Freeze())
 }
 
 func TestValueObjectControlAPIsInvalidReceiver(t *testing.T) {

--- a/value_test.go
+++ b/value_test.go
@@ -60,6 +60,105 @@ func TestValueBasics(t *testing.T) {
 	require.True(t, sym.IsSymbol())
 }
 
+func TestValueComparisonAPIs(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	one := ctx.NewInt32(1)
+	defer one.Free()
+	oneStr := ctx.NewString("1")
+	defer oneStr.Free()
+
+	require.True(t, one.Equal(oneStr))
+	require.False(t, one.StrictEqual(oneStr))
+
+	nanA := ctx.Eval("NaN")
+	defer nanA.Free()
+	nanB := ctx.Eval("NaN")
+	defer nanB.Free()
+	require.False(t, nanA.Equal(nanB))
+	require.False(t, nanA.StrictEqual(nanB))
+	require.True(t, nanA.SameValue(nanB))
+	require.True(t, nanA.SameValueZero(nanB))
+
+	plusZero := ctx.Eval("+0")
+	defer plusZero.Free()
+	minusZero := ctx.Eval("-0")
+	defer minusZero.Free()
+	require.True(t, plusZero.Equal(minusZero))
+	require.True(t, plusZero.StrictEqual(minusZero))
+	require.False(t, plusZero.SameValue(minusZero))
+	require.True(t, plusZero.SameValueZero(minusZero))
+
+	ctx2 := rt.NewContext()
+	defer ctx2.Close()
+	other := ctx2.NewInt32(1)
+	defer other.Free()
+	require.False(t, one.Equal(other))
+	require.False(t, one.StrictEqual(other))
+	require.False(t, one.SameValue(other))
+	require.False(t, one.SameValueZero(other))
+}
+
+func TestValueObjectControlAPIs(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	obj := ctx.NewObject()
+	defer obj.Free()
+	proto := ctx.NewObject()
+	defer proto.Free()
+	proto.Set("kind", ctx.NewString("proto"))
+
+	require.True(t, obj.SetPrototype(proto))
+	actualProto := obj.Prototype()
+	require.NotNil(t, actualProto)
+	defer actualProto.Free()
+	kind := actualProto.Get("kind")
+	defer kind.Free()
+	require.Equal(t, "proto", kind.ToString())
+
+	require.True(t, obj.IsExtensible())
+	require.True(t, obj.PreventExtensions())
+	require.False(t, obj.IsExtensible())
+
+	sealed := ctx.Eval("({ a: 1 })")
+	defer sealed.Free()
+	require.True(t, sealed.Seal())
+	require.False(t, sealed.IsExtensible())
+
+	frozen := ctx.Eval("({ a: 1 })")
+	defer frozen.Free()
+	require.True(t, frozen.Freeze())
+	require.False(t, frozen.IsExtensible())
+
+	ctx2 := rt.NewContext()
+	defer ctx2.Close()
+	otherProto := ctx2.NewObject()
+	defer otherProto.Free()
+	require.False(t, obj.SetPrototype(otherProto))
+}
+
+func TestValueObjectControlAPIsInvalidReceiver(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
+	var nilValue *Value
+	require.Nil(t, nilValue.Prototype())
+	require.False(t, nilValue.IsExtensible())
+	require.False(t, nilValue.PreventExtensions())
+	require.False(t, nilValue.Seal())
+	require.False(t, nilValue.Freeze())
+	require.False(t, nilValue.SetPrototype(nil))
+}
+
 // TestValueConversions tests type conversions including deprecated methods
 func TestValueConversions(t *testing.T) {
 	useStableOwnerHooksForLegacySubtests(t)


### PR DESCRIPTION
Implement Equal/StrictEqual/SameValue/SameValueZero and object control helpers (Prototype, SetPrototype, IsExtensible, PreventExtensions, Seal, Freeze).

Add comprehensive tests for semantics, cross-context fail-closed behavior, and invalid receiver paths.