### PR TITLE
feat: add property descriptor and atom/int64 shortcuts

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -37,6 +37,14 @@ func (a *Atom) ToValue() *Value {
 	return &Value{ctx: a.ctx, ref: C.JS_AtomToValue(a.ctx.ref, a.ref)}
 }
 
+// Dup increments the atom reference count and returns a new Atom handle.
+func (a *Atom) Dup() *Atom {
+	if a == nil || a.ctx == nil || !a.ctx.hasValidRef() {
+		return nil
+	}
+	return &Atom{ctx: a.ctx, ref: C.JS_DupAtom(a.ctx.ref, a.ref)}
+}
+
 // Value returns the value representation of the atom.
 // Deprecated: Use ToValue() instead.
 func (a *Atom) Value() *Value {

--- a/atom_test.go
+++ b/atom_test.go
@@ -408,6 +408,12 @@ func TestAtomDupAndContextAtomFromValue(t *testing.T) {
 	defer objAtom.Free()
 	require.Equal(t, "[object Object]", objAtom.ToString())
 
+	badKey := ctx.Eval(`({ toString(){ throw new Error('boom') } })`)
+	defer badKey.Free()
+	require.False(t, badKey.IsException())
+	require.Nil(t, ctx.AtomFromValue(badKey))
+	require.Error(t, ctx.Exception())
+
 	var nilAtom *Atom
 	require.Nil(t, nilAtom.Dup())
 

--- a/atom_test.go
+++ b/atom_test.go
@@ -374,3 +374,50 @@ func TestAtomEdgeCases(t *testing.T) {
 		require.Equal(t, propName, atomValue.ToString()) // Changed: String() → ToString()
 	})
 }
+
+func TestAtomDupAndContextAtomFromValue(t *testing.T) {
+	rt := NewRuntime()
+	defer rt.Close()
+
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	name := ctx.NewString("dup-key")
+	defer name.Free()
+
+	atom := ctx.AtomFromValue(name)
+	require.NotNil(t, atom)
+	defer atom.Free()
+	require.Equal(t, "dup-key", atom.ToString())
+
+	dup := atom.Dup()
+	require.NotNil(t, dup)
+	defer dup.Free()
+	require.Equal(t, atom.ToString(), dup.ToString())
+
+	ctx2 := rt.NewContext()
+	defer ctx2.Close()
+	foreignVal := ctx2.NewString("foreign")
+	defer foreignVal.Free()
+	require.Nil(t, ctx.AtomFromValue(foreignVal))
+
+	obj := ctx.NewObject()
+	defer obj.Free()
+	objAtom := ctx.AtomFromValue(obj)
+	require.NotNil(t, objAtom)
+	defer objAtom.Free()
+	require.Equal(t, "[object Object]", objAtom.ToString())
+
+	var nilAtom *Atom
+	require.Nil(t, nilAtom.Dup())
+
+	var nilCtx *Context
+	require.Nil(t, nilCtx.AtomFromValue(name))
+
+	closedRT := NewRuntime()
+	closedCtx := closedRT.NewContext()
+	closedVal := closedCtx.NewString("closed")
+	closedCtx.Close()
+	require.Nil(t, closedCtx.AtomFromValue(closedVal))
+	closedRT.Close()
+}

--- a/context.go
+++ b/context.go
@@ -746,6 +746,9 @@ func (ctx *Context) AtomFromValue(v *Value) *Atom {
 		return nil
 	}
 	atom := C.JS_ValueToAtom(ctx.ref, v.ref)
+	if atom == C.JS_ATOM_NULL {
+		return nil
+	}
 	return &Atom{ctx: ctx, ref: atom}
 }
 

--- a/context.go
+++ b/context.go
@@ -740,6 +740,15 @@ func (ctx *Context) NewAtomIdx(idx uint32) *Atom {
 	return &Atom{ctx: ctx, ref: C.JS_NewAtomUInt32(ctx.ref, C.uint32_t(idx))}
 }
 
+// AtomFromValue converts a value to an atom key.
+func (ctx *Context) AtomFromValue(v *Value) *Atom {
+	if ctx == nil || !ctx.hasValidRef() || !v.belongsTo(ctx) {
+		return nil
+	}
+	atom := C.JS_ValueToAtom(ctx.ref, v.ref)
+	return &Atom{ctx: ctx, ref: atom}
+}
+
 // AtomIdx returns a new Atom value with given idx.
 // Deprecated: Use NewAtomIdx() instead.
 func (ctx *Context) AtomIdx(idx uint32) *Atom {

--- a/value.go
+++ b/value.go
@@ -23,6 +23,15 @@ type Value struct {
 	borrowed bool
 }
 
+// PropertyDescriptor mirrors QuickJS property descriptor semantics.
+// Value/Getter/Setter returned by OwnProperty are owned by caller and must be freed.
+type PropertyDescriptor struct {
+	Flags  int
+	Value  *Value
+	Getter *Value
+	Setter *Value
+}
+
 // hasValidContext reports whether a Value still has a usable context pointer.
 func (v *Value) hasValidContext() bool {
 	return v != nil && v.ctx != nil && v.ctx.hasValidRef()
@@ -460,6 +469,162 @@ func (v *Value) DeleteIdx(idx uint32) bool {
 		return false // Property does not exist, nothing to delete
 	}
 	return C.JS_DeletePropertyInt64(v.ctx.ref, v.ref, C.int64_t(idx), C.int(1)) == 1
+}
+
+// DefineProperty defines a property using a full descriptor.
+func (v *Value) DefineProperty(name string, desc PropertyDescriptor) bool {
+	if !v.isAlive() {
+		return false
+	}
+	atom := v.ctx.NewAtom(name)
+	defer atom.Free()
+	return v.DefinePropertyAtom(atom, desc)
+}
+
+// DefinePropertyAtom defines a property using a full descriptor and a pre-built atom.
+func (v *Value) DefinePropertyAtom(atom *Atom, desc PropertyDescriptor) bool {
+	if !v.isAlive() || atom == nil || atom.ctx == nil || atom.ctx != v.ctx || !atom.ctx.hasValidRef() {
+		return false
+	}
+	if desc.Value != nil && !desc.Value.belongsTo(v.ctx) {
+		return false
+	}
+	if desc.Getter != nil && !desc.Getter.belongsTo(v.ctx) {
+		return false
+	}
+	if desc.Setter != nil && !desc.Setter.belongsTo(v.ctx) {
+		return false
+	}
+
+	value := C.JS_NewUndefined()
+	if desc.Value != nil {
+		value = desc.Value.ref
+	}
+	getter := C.JS_NewUndefined()
+	if desc.Getter != nil {
+		getter = desc.Getter.ref
+	}
+	setter := C.JS_NewUndefined()
+	if desc.Setter != nil {
+		setter = desc.Setter.ref
+	}
+
+	ret := C.JS_DefineProperty(v.ctx.ref, v.ref, atom.ref, value, getter, setter, C.int(desc.Flags))
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
+}
+
+// DefinePropertyValue defines a value property by name.
+func (v *Value) DefinePropertyValue(name string, value *Value, flags int) bool {
+	if !v.isAlive() || !value.belongsTo(v.ctx) {
+		return false
+	}
+	atom := v.ctx.NewAtom(name)
+	defer atom.Free()
+
+	dup := C.JS_DupValue(v.ctx.ref, value.ref)
+	ret := C.JS_DefinePropertyValue(v.ctx.ref, v.ref, atom.ref, dup, C.int(flags))
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
+}
+
+// DefinePropertyGetSet defines an accessor property by name.
+func (v *Value) DefinePropertyGetSet(name string, getter *Value, setter *Value, flags int) bool {
+	if !v.isAlive() {
+		return false
+	}
+	if getter != nil && !getter.belongsTo(v.ctx) {
+		return false
+	}
+	if setter != nil && !setter.belongsTo(v.ctx) {
+		return false
+	}
+	atom := v.ctx.NewAtom(name)
+	defer atom.Free()
+
+	getterRef := C.JS_NewUndefined()
+	setterRef := C.JS_NewUndefined()
+	if getter != nil {
+		getterRef = C.JS_DupValue(v.ctx.ref, getter.ref)
+	}
+	if setter != nil {
+		setterRef = C.JS_DupValue(v.ctx.ref, setter.ref)
+	}
+
+	ret := C.JS_DefinePropertyGetSet(v.ctx.ref, v.ref, atom.ref, getterRef, setterRef, C.int(flags))
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
+}
+
+// OwnProperty gets a full own property descriptor by name.
+func (v *Value) OwnProperty(name string) (*PropertyDescriptor, bool) {
+	if !v.isAlive() {
+		return nil, false
+	}
+	atom := v.ctx.NewAtom(name)
+	defer atom.Free()
+
+	var desc C.JSPropertyDescriptor
+	ret := C.JS_GetOwnProperty(v.ctx.ref, &desc, v.ref, atom.ref)
+	if ret <= 0 {
+		return nil, false
+	}
+
+	result := &PropertyDescriptor{
+		Flags:  int(desc.flags),
+		Value:  &Value{ctx: v.ctx, ref: desc.value},
+		Getter: &Value{ctx: v.ctx, ref: desc.getter},
+		Setter: &Value{ctx: v.ctx, ref: desc.setter},
+	}
+	return result, true
+}
+
+// GetAtom gets a property by atom key.
+func (v *Value) GetAtom(atom *Atom) *Value {
+	if !v.isAlive() || atom == nil || atom.ctx == nil || atom.ctx != v.ctx || !atom.ctx.hasValidRef() {
+		return nil
+	}
+	return &Value{ctx: v.ctx, ref: C.JS_GetProperty(v.ctx.ref, v.ref, atom.ref)}
+}
+
+// SetAtom sets a property by atom key.
+func (v *Value) SetAtom(atom *Atom, val *Value) bool {
+	if !v.isAlive() || atom == nil || atom.ctx == nil || atom.ctx != v.ctx || !atom.ctx.hasValidRef() || !val.belongsTo(v.ctx) {
+		return false
+	}
+	dup := C.JS_DupValue(v.ctx.ref, val.ref)
+	ret := C.JS_SetProperty(v.ctx.ref, v.ref, atom.ref, dup)
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
+}
+
+// GetInt64 gets a property by int64 key.
+func (v *Value) GetInt64(idx int64) *Value {
+	if !v.hasValidContext() {
+		return nil
+	}
+	return &Value{ctx: v.ctx, ref: C.JS_GetPropertyInt64(v.ctx.ref, v.ref, C.int64_t(idx))}
+}
+
+// SetInt64 sets a property by int64 key.
+func (v *Value) SetInt64(idx int64, val *Value) bool {
+	if !v.isAlive() || !val.belongsTo(v.ctx) {
+		return false
+	}
+	dup := C.JS_DupValue(v.ctx.ref, val.ref)
+	ret := C.JS_SetPropertyInt64(v.ctx.ref, v.ref, C.int64_t(idx), dup)
+	if ret < 0 {
+		return false
+	}
+	return ret == 1
 }
 
 // Prototype returns the object's prototype value.

--- a/value.go
+++ b/value.go
@@ -512,14 +512,17 @@ func (v *Value) DefinePropertyAtom(atom *Atom, desc PropertyDescriptor) bool {
 
 	value := C.JS_NewUndefined()
 	if desc.Value != nil {
+		// JS_DefineProperty borrows descriptor values; do not transfer caller ownership.
 		value = desc.Value.ref
 	}
 	getter := C.JS_NewUndefined()
 	if desc.Getter != nil {
+		// Borrowed argument: keep caller-managed getter handle valid after the call.
 		getter = desc.Getter.ref
 	}
 	setter := C.JS_NewUndefined()
 	if desc.Setter != nil {
+		// Borrowed argument: keep caller-managed setter handle valid after the call.
 		setter = desc.Setter.ref
 	}
 
@@ -538,6 +541,7 @@ func (v *Value) DefinePropertyValue(name string, value *Value, flags int) bool {
 	atom := v.ctx.NewAtom(name)
 	defer atom.Free()
 
+	// JS_DefinePropertyValue consumes `dup` but does not consume `atom`.
 	dup := C.JS_DupValue(v.ctx.ref, value.ref)
 	ret := C.JS_DefinePropertyValue(v.ctx.ref, v.ref, atom.ref, dup, C.int(flags))
 	if ret < 0 {
@@ -563,9 +567,11 @@ func (v *Value) DefinePropertyGetSet(name string, getter *Value, setter *Value, 
 	getterRef := C.JS_NewUndefined()
 	setterRef := C.JS_NewUndefined()
 	if getter != nil {
+		// JS_DefinePropertyGetSet consumes getter/setter values.
 		getterRef = C.JS_DupValue(v.ctx.ref, getter.ref)
 	}
 	if setter != nil {
+		// JS_DefinePropertyGetSet consumes getter/setter values.
 		setterRef = C.JS_DupValue(v.ctx.ref, setter.ref)
 	}
 
@@ -604,6 +610,7 @@ func (v *Value) GetAtom(atom *Atom) *Value {
 	if !v.isAlive() || atom == nil || atom.ctx == nil || atom.ctx != v.ctx || !atom.ctx.hasValidRef() {
 		return nil
 	}
+	// JS_GetProperty borrows atom; caller retains atom ownership.
 	return &Value{ctx: v.ctx, ref: C.JS_GetProperty(v.ctx.ref, v.ref, atom.ref)}
 }
 
@@ -612,6 +619,7 @@ func (v *Value) SetAtom(atom *Atom, val *Value) bool {
 	if !v.isAlive() || atom == nil || atom.ctx == nil || atom.ctx != v.ctx || !atom.ctx.hasValidRef() || !val.belongsTo(v.ctx) {
 		return false
 	}
+	// JS_SetProperty consumes `dup` but borrows `atom`.
 	dup := C.JS_DupValue(v.ctx.ref, val.ref)
 	ret := C.JS_SetProperty(v.ctx.ref, v.ref, atom.ref, dup)
 	if ret < 0 {

--- a/value.go
+++ b/value.go
@@ -32,6 +32,20 @@ type PropertyDescriptor struct {
 	Setter *Value
 }
 
+// Property descriptor flags matching QuickJS JS_PROP_* constants.
+const (
+	PropConfigurable = 1 << 0
+	PropWritable     = 1 << 1
+	PropEnumerable   = 1 << 2
+
+	PropHasConfigurable = 1 << 8
+	PropHasWritable     = 1 << 9
+	PropHasEnumerable   = 1 << 10
+	PropHasGet          = 1 << 11
+	PropHasSet          = 1 << 12
+	PropHasValue        = 1 << 13
+)
+
 // hasValidContext reports whether a Value still has a usable context pointer.
 func (v *Value) hasValidContext() bool {
 	return v != nil && v.ctx != nil && v.ctx.hasValidRef()

--- a/value_test.go
+++ b/value_test.go
@@ -199,14 +199,6 @@ func TestValueObjectControlAPIsInvalidReceiver(t *testing.T) {
 func TestValuePropertyDescriptorAndAtomInt64APIs(t *testing.T) {
 	useStableOwnerHooksForLegacySubtests(t)
 
-	const (
-		propConfigurable    = 1 << 0
-		propWritable        = 1 << 1
-		propHasConfigurable = 1 << 8
-		propHasWritable     = 1 << 9
-		propHasValue        = 1 << 13
-	)
-
 	rt := NewRuntime()
 	defer rt.Close()
 	ctx := rt.NewContext()
@@ -227,7 +219,7 @@ func TestValuePropertyDescriptorAndAtomInt64APIs(t *testing.T) {
 	v2Local := ctx.NewInt32(8)
 	defer v2Local.Free()
 	require.True(t, obj.DefinePropertyAtom(atomX, PropertyDescriptor{
-		Flags: propHasValue | propHasWritable | propHasConfigurable | propWritable | propConfigurable,
+		Flags: PropHasValue | PropHasWritable | PropHasConfigurable | PropWritable | PropConfigurable,
 		Value: v2Local,
 	}))
 	x2 := obj.Get("x2")
@@ -237,7 +229,7 @@ func TestValuePropertyDescriptorAndAtomInt64APIs(t *testing.T) {
 	v3Local := ctx.NewInt32(11)
 	defer v3Local.Free()
 	require.True(t, obj.DefineProperty("x3", PropertyDescriptor{
-		Flags: propHasValue | propHasWritable | propHasConfigurable | propWritable | propConfigurable,
+		Flags: PropHasValue | PropHasWritable | PropHasConfigurable | PropWritable | PropConfigurable,
 		Value: v3Local,
 	}))
 	x3 := obj.Get("x3")
@@ -353,7 +345,7 @@ func TestValuePropertyDescriptorAndAtomInt64APIs(t *testing.T) {
 	require.False(t, throwDefineProxy.DefinePropertyGetSet("q", getter, setter, 0))
 	require.Error(t, ctx.Exception())
 	require.False(t, throwDefineProxy.DefinePropertyAtom(atomKey, PropertyDescriptor{
-		Flags: propHasValue | propHasWritable | propHasConfigurable | propWritable | propConfigurable,
+		Flags: PropHasValue | PropHasWritable | PropHasConfigurable | PropWritable | PropConfigurable,
 		Value: v,
 	}))
 	require.Error(t, ctx.Exception())

--- a/value_test.go
+++ b/value_test.go
@@ -196,6 +196,193 @@ func TestValueObjectControlAPIsInvalidReceiver(t *testing.T) {
 	require.False(t, nilValue.SetPrototype(nil))
 }
 
+func TestValuePropertyDescriptorAndAtomInt64APIs(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
+	const (
+		propConfigurable    = 1 << 0
+		propWritable        = 1 << 1
+		propHasConfigurable = 1 << 8
+		propHasWritable     = 1 << 9
+		propHasValue        = 1 << 13
+	)
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	obj := ctx.NewObject()
+	defer obj.Free()
+
+	v := ctx.NewInt32(7)
+	defer v.Free()
+	require.True(t, obj.DefinePropertyValue("x", v, 0))
+	x := obj.Get("x")
+	defer x.Free()
+	require.Equal(t, int32(7), x.ToInt32())
+
+	atomX := ctx.NewAtom("x2")
+	defer atomX.Free()
+	v2Local := ctx.NewInt32(8)
+	defer v2Local.Free()
+	require.True(t, obj.DefinePropertyAtom(atomX, PropertyDescriptor{
+		Flags: propHasValue | propHasWritable | propHasConfigurable | propWritable | propConfigurable,
+		Value: v2Local,
+	}))
+	x2 := obj.Get("x2")
+	defer x2.Free()
+	require.Equal(t, int32(8), x2.ToInt32())
+
+	v3Local := ctx.NewInt32(11)
+	defer v3Local.Free()
+	require.True(t, obj.DefineProperty("x3", PropertyDescriptor{
+		Flags: propHasValue | propHasWritable | propHasConfigurable | propWritable | propConfigurable,
+		Value: v3Local,
+	}))
+	x3 := obj.Get("x3")
+	defer x3.Free()
+	require.Equal(t, int32(11), x3.ToInt32())
+
+	getter := ctx.Eval(`(function(){ return 42; })`)
+	defer getter.Free()
+	setter := ctx.Eval(`(function(v){ this._s = v; })`)
+	defer setter.Free()
+	require.True(t, obj.DefinePropertyGetSet("gs", getter, setter, 0))
+
+	atomGS := ctx.NewAtom("gs2")
+	defer atomGS.Free()
+	require.True(t, obj.DefinePropertyAtom(atomGS, PropertyDescriptor{
+		Getter: getter,
+		Setter: setter,
+	}))
+
+	setVal := ctx.NewInt32(9)
+	defer setVal.Free()
+	obj.Set("gs", setVal)
+	s := obj.Get("_s")
+	defer s.Free()
+	require.Equal(t, int32(9), s.ToInt32())
+	obj.Set("gs2", setVal)
+	s2 := obj.Get("_s")
+	defer s2.Free()
+	require.Equal(t, int32(9), s2.ToInt32())
+
+	desc, ok := obj.OwnProperty("x")
+	require.True(t, ok)
+	require.NotNil(t, desc)
+	require.NotNil(t, desc.Value)
+	require.NotNil(t, desc.Getter)
+	require.NotNil(t, desc.Setter)
+	defer desc.Value.Free()
+	defer desc.Getter.Free()
+	defer desc.Setter.Free()
+	require.Equal(t, int32(7), desc.Value.ToInt32())
+
+	missing, found := obj.OwnProperty("missing")
+	require.False(t, found)
+	require.Nil(t, missing)
+
+	atomKey := ctx.NewAtom("a")
+	defer atomKey.Free()
+	atomVal := ctx.NewString("ok")
+	defer atomVal.Free()
+	require.True(t, obj.SetAtom(atomKey, atomVal))
+	gotAtomVal := obj.GetAtom(atomKey)
+	require.NotNil(t, gotAtomVal)
+	defer gotAtomVal.Free()
+	require.Equal(t, "ok", gotAtomVal.ToString())
+
+	int64Val := ctx.NewString("i64")
+	defer int64Val.Free()
+	require.True(t, obj.SetInt64(123456789, int64Val))
+	gotInt64Val := obj.GetInt64(123456789)
+	require.NotNil(t, gotInt64Val)
+	defer gotInt64Val.Free()
+	require.Equal(t, "i64", gotInt64Val.ToString())
+
+	ctx2 := rt.NewContext()
+	defer ctx2.Close()
+	v2 := ctx2.NewInt32(1)
+	defer v2.Free()
+	atom2 := ctx2.NewAtom("b")
+	defer atom2.Free()
+
+	require.False(t, obj.DefinePropertyValue("bad", v2, 0))
+	require.False(t, obj.DefinePropertyGetSet("badGetter", v2, setter, 0))
+	require.False(t, obj.DefinePropertyGetSet("bad2", getter, v2, 0))
+	require.False(t, obj.DefinePropertyAtom(atomKey, PropertyDescriptor{Getter: v2}))
+	require.False(t, obj.DefinePropertyAtom(atomKey, PropertyDescriptor{Setter: v2}))
+	require.False(t, obj.DefinePropertyAtom(atom2, PropertyDescriptor{Value: v}))
+	require.False(t, obj.DefinePropertyAtom(nil, PropertyDescriptor{Value: v}))
+
+	closedRT := NewRuntime()
+	closedCtx := closedRT.NewContext()
+	closedAtom := closedCtx.NewAtom("closed")
+	closedCtx.Close()
+	require.False(t, obj.DefinePropertyAtom(closedAtom, PropertyDescriptor{Value: v}))
+	closedRT.Close()
+
+	require.Nil(t, obj.GetAtom(atom2))
+	require.False(t, obj.SetAtom(atom2, atomVal))
+	require.False(t, obj.SetInt64(1, v2))
+
+	nilObj := (*Value)(nil)
+	require.False(t, nilObj.DefineProperty("x", PropertyDescriptor{}))
+	require.False(t, nilObj.DefinePropertyValue("x", v, 0))
+	require.False(t, nilObj.DefinePropertyGetSet("x", getter, setter, 0))
+	nilDesc, nilDescOK := nilObj.OwnProperty("x")
+	require.False(t, nilDescOK)
+	require.Nil(t, nilDesc)
+	require.Nil(t, nilObj.GetAtom(atomKey))
+	require.False(t, nilObj.SetAtom(atomKey, atomVal))
+	require.Nil(t, nilObj.GetInt64(1))
+	require.False(t, nilObj.SetInt64(1, atomVal))
+
+	require.False(t, obj.DefineProperty("bad3", PropertyDescriptor{Value: v2}))
+
+	throwDefineProxy := ctx.Eval(`
+		new Proxy({}, {
+			defineProperty() { throw new Error('define trap error') }
+		})
+	`)
+	defer throwDefineProxy.Free()
+	require.False(t, throwDefineProxy.IsException())
+	require.False(t, throwDefineProxy.DefinePropertyValue("p", v, 0))
+	require.Error(t, ctx.Exception())
+	require.False(t, throwDefineProxy.DefinePropertyGetSet("q", getter, setter, 0))
+	require.Error(t, ctx.Exception())
+	require.False(t, throwDefineProxy.DefinePropertyAtom(atomKey, PropertyDescriptor{
+		Flags: propHasValue | propHasWritable | propHasConfigurable | propWritable | propConfigurable,
+		Value: v,
+	}))
+	require.Error(t, ctx.Exception())
+
+	throwOwnPropertyProxy := ctx.Eval(`
+		new Proxy({}, {
+			getOwnPropertyDescriptor() { throw new Error('gopd trap error') }
+		})
+	`)
+	defer throwOwnPropertyProxy.Free()
+	require.False(t, throwOwnPropertyProxy.IsException())
+	badDesc, badOk := throwOwnPropertyProxy.OwnProperty("x")
+	require.False(t, badOk)
+	require.Nil(t, badDesc)
+	require.Error(t, ctx.Exception())
+
+	throwSetProxy := ctx.Eval(`
+		new Proxy({}, {
+			set() { throw new Error('set trap error') }
+		})
+	`)
+	defer throwSetProxy.Free()
+	require.False(t, throwSetProxy.IsException())
+	require.False(t, throwSetProxy.SetAtom(atomKey, atomVal))
+	require.Error(t, ctx.Exception())
+	require.False(t, throwSetProxy.SetInt64(123, atomVal))
+	require.Error(t, ctx.Exception())
+}
+
 // TestValueConversions tests type conversions including deprecated methods
 func TestValueConversions(t *testing.T) {
 	useStableOwnerHooksForLegacySubtests(t)


### PR DESCRIPTION
- add PropertyDescriptor and define/get/set helpers on Value
- add Context.AtomFromValue and Atom.Dup
- add comprehensive tests for success, cross-context failures, and exception paths