### PR TITLE
feat: add context/libc Stage 4 helper APIs

### DIFF
--- a/context.go
+++ b/context.go
@@ -1013,7 +1013,7 @@ func (ctx *Context) LoadModuleBytecode(buf []byte, opts ...EvalOption) *Value {
 
 // SetImportMeta sets import.meta for a compiled module function.
 func (ctx *Context) SetImportMeta(moduleFunc *Value, useRealPath bool, isMain bool) bool {
-	if !ctx.hasValidRef() || moduleFunc == nil || !moduleFunc.belongsTo(ctx) {
+	if !ctx.hasValidRef() || !moduleFunc.belongsTo(ctx) {
 		return false
 	}
 	return C.js_module_set_import_meta(ctx.ref, moduleFunc.ref, C.bool(useRealPath), C.bool(isMain)) == 0
@@ -1021,7 +1021,7 @@ func (ctx *Context) SetImportMeta(moduleFunc *Value, useRealPath bool, isMain bo
 
 // BootstrapBJSON registers the bjson module for the context.
 func (ctx *Context) BootstrapBJSON() bool {
-	if ctx == nil || !ctx.hasValidRef() {
+	if !ctx.hasValidRef() {
 		return false
 	}
 	moduleName := C.CString("bjson")

--- a/context.go
+++ b/context.go
@@ -1020,7 +1020,7 @@ func (ctx *Context) SetImportMeta(moduleFunc *Value, useRealPath bool, isMain bo
 }
 
 // BootstrapBJSON registers the bjson module for the context.
-func BootstrapBJSON(ctx *Context) bool {
+func (ctx *Context) BootstrapBJSON() bool {
 	if ctx == nil || !ctx.hasValidRef() {
 		return false
 	}

--- a/context.go
+++ b/context.go
@@ -380,6 +380,34 @@ func (ctx *Context) NewString(v string) *Value {
 	return &Value{ctx: ctx, ref: C.JS_NewStringLen(ctx.ref, ptr, C.size_t(len(v)))}
 }
 
+// NewDate returns a JavaScript Date object from epoch milliseconds.
+func (ctx *Context) NewDate(epochMS float64) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
+	return &Value{ctx: ctx, ref: C.JS_NewDate(ctx.ref, C.double(epochMS))}
+}
+
+// NewSymbol returns a JavaScript local symbol.
+func (ctx *Context) NewSymbol(description string) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
+	desc := C.CString(description)
+	defer C.free(unsafe.Pointer(desc))
+	return &Value{ctx: ctx, ref: C.JS_NewSymbol(ctx.ref, desc, C.bool(false))}
+}
+
+// NewGlobalSymbol returns a JavaScript global symbol.
+func (ctx *Context) NewGlobalSymbol(description string) *Value {
+	if !ctx.hasValidRef() {
+		return nil
+	}
+	desc := C.CString(description)
+	defer C.free(unsafe.Pointer(desc))
+	return &Value{ctx: ctx, ref: C.JS_NewSymbol(ctx.ref, desc, C.bool(true))}
+}
+
 // String returns a string value with given string.
 // Deprecated: Use NewString() instead.
 func (ctx *Context) String(v string) *Value {
@@ -983,6 +1011,24 @@ func (ctx *Context) LoadModuleBytecode(buf []byte, opts ...EvalOption) *Value {
 	return &Value{ctx: ctx, ref: cVal}
 }
 
+// SetImportMeta sets import.meta for a compiled module function.
+func (ctx *Context) SetImportMeta(moduleFunc *Value, useRealPath bool, isMain bool) bool {
+	if !ctx.hasValidRef() || moduleFunc == nil || !moduleFunc.belongsTo(ctx) {
+		return false
+	}
+	return C.js_module_set_import_meta(ctx.ref, moduleFunc.ref, C.bool(useRealPath), C.bool(isMain)) == 0
+}
+
+// BootstrapBJSON registers the bjson module for the context.
+func BootstrapBJSON(ctx *Context) bool {
+	if ctx == nil || !ctx.hasValidRef() {
+		return false
+	}
+	moduleName := C.CString("bjson")
+	defer C.free(unsafe.Pointer(moduleName))
+	return C.js_init_module_bjson(ctx.ref, moduleName) != nil
+}
+
 // EvalBytecode returns a js value with given bytecode.
 // Need call Free() `quickjs.Value`'s returned by `Eval()` and `EvalFile()` and `EvalBytecode()`.
 func (ctx *Context) EvalBytecode(buf []byte) *Value {
@@ -1155,6 +1201,36 @@ func (ctx *Context) Loop() {
 	ctx.ProcessJobs()
 	C.js_std_loop(ctx.ref)
 	ctx.ProcessJobs()
+}
+
+// LoopOnce runs one event-loop iteration and returns QuickJS libc status.
+func (ctx *Context) LoopOnce() int {
+	if !ctx.hasValidRef() {
+		return -1
+	}
+	ctx.ProcessJobs()
+	ret := int(C.js_std_loop_once(ctx.ref))
+	ctx.ProcessJobs()
+	return ret
+}
+
+// PollIO polls host I/O and returns QuickJS libc status.
+func (ctx *Context) PollIO(timeoutMS int) int {
+	if !ctx.hasValidRef() {
+		return -1
+	}
+	ctx.ProcessJobs()
+	ret := int(C.js_std_poll_io(ctx.ref, C.int(timeoutMS)))
+	ctx.ProcessJobs()
+	return ret
+}
+
+// DumpError prints and clears current exception using QuickJS libc helper.
+func (ctx *Context) DumpError() {
+	if !ctx.hasValidRef() {
+		return
+	}
+	C.js_std_dump_error(ctx.ref)
 }
 
 // Wait for a promise and execute pending jobs while waiting for it.

--- a/context_test.go
+++ b/context_test.go
@@ -340,6 +340,106 @@ func TestContextBytecodeOperations(t *testing.T) {
 	})
 }
 
+func TestContextLibcStage4Helpers(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	date := ctx.NewDate(1700000000000)
+	require.NotNil(t, date)
+	defer date.Free()
+	require.True(t, date.IsDate())
+
+	localSym := ctx.NewSymbol("local-key")
+	require.NotNil(t, localSym)
+	require.True(t, localSym.IsSymbol())
+
+	globalSym := ctx.NewGlobalSymbol("global-key")
+	require.NotNil(t, globalSym)
+	require.True(t, globalSym.IsSymbol())
+
+	globals := ctx.Globals()
+	require.NotNil(t, globals)
+	globals.Set("_localSym", localSym)
+	globals.Set("_globalSym", globalSym)
+
+	localKey := ctx.Eval(`Symbol.keyFor(globalThis._localSym)`)
+	require.NotNil(t, localKey)
+	defer localKey.Free()
+	require.True(t, localKey.IsUndefined())
+
+	globalKey := ctx.Eval(`Symbol.keyFor(globalThis._globalSym)`)
+	require.NotNil(t, globalKey)
+	defer globalKey.Free()
+	require.False(t, globalKey.IsException())
+	require.Equal(t, "global-key", globalKey.ToString())
+
+	moduleFunc := ctx.Eval(`export const v = 1`, EvalFlagModule(true), EvalFlagCompileOnly(true))
+	require.NotNil(t, moduleFunc)
+	defer moduleFunc.Free()
+	require.False(t, moduleFunc.IsException())
+	require.True(t, ctx.SetImportMeta(moduleFunc, false, false))
+
+	ctx2 := rt.NewContext()
+	require.NotNil(t, ctx2)
+	defer ctx2.Close()
+	foreignModuleFunc := ctx2.Eval(`export const v = 2`, EvalFlagModule(true), EvalFlagCompileOnly(true))
+	require.NotNil(t, foreignModuleFunc)
+	defer foreignModuleFunc.Free()
+	require.False(t, foreignModuleFunc.IsException())
+	require.False(t, ctx.SetImportMeta(foreignModuleFunc, false, false))
+
+	require.True(t, BootstrapBJSON(ctx))
+	require.GreaterOrEqual(t, ctx.LoopOnce(), -1)
+	require.GreaterOrEqual(t, ctx.PollIO(0), -1)
+
+	bad := ctx.Eval(`throw new Error("dump error")`)
+	require.NotNil(t, bad)
+	defer bad.Free()
+	require.True(t, bad.IsException())
+	require.NotPanics(t, func() {
+		ctx.DumpError()
+	})
+}
+
+func TestContextLibcStage4HelpersNilAndClosedGuards(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
+	var nilCtx *Context
+	require.Nil(t, nilCtx.NewDate(0))
+	require.Nil(t, nilCtx.NewSymbol("x"))
+	require.Nil(t, nilCtx.NewGlobalSymbol("x"))
+	require.False(t, nilCtx.SetImportMeta(nil, false, false))
+	require.False(t, BootstrapBJSON(nilCtx))
+	require.Equal(t, -1, nilCtx.LoopOnce())
+	require.Equal(t, -1, nilCtx.PollIO(1))
+	require.NotPanics(t, func() { nilCtx.DumpError() })
+
+	rt := NewRuntime()
+	ctx := rt.NewContext()
+	require.NotNil(t, ctx)
+
+	moduleFunc := ctx.Eval(`export const k = 1`, EvalFlagModule(true), EvalFlagCompileOnly(true))
+	require.NotNil(t, moduleFunc)
+	defer moduleFunc.Free()
+	require.False(t, moduleFunc.IsException())
+
+	ctx.Close()
+	require.Nil(t, ctx.NewDate(0))
+	require.Nil(t, ctx.NewSymbol("x"))
+	require.Nil(t, ctx.NewGlobalSymbol("x"))
+	require.False(t, ctx.SetImportMeta(moduleFunc, false, false))
+	require.False(t, BootstrapBJSON(ctx))
+	require.Equal(t, -1, ctx.LoopOnce())
+	require.Equal(t, -1, ctx.PollIO(1))
+	require.NotPanics(t, func() { ctx.DumpError() })
+
+	rt.Close()
+}
+
 func TestContextModules(t *testing.T) {
 	useStableOwnerHooksForLegacySubtests(t)
 

--- a/context_test.go
+++ b/context_test.go
@@ -392,7 +392,7 @@ func TestContextLibcStage4Helpers(t *testing.T) {
 	require.False(t, foreignModuleFunc.IsException())
 	require.False(t, ctx.SetImportMeta(foreignModuleFunc, false, false))
 
-	require.True(t, BootstrapBJSON(ctx))
+	require.True(t, ctx.BootstrapBJSON())
 	require.GreaterOrEqual(t, ctx.LoopOnce(), -1)
 	require.GreaterOrEqual(t, ctx.PollIO(0), -1)
 
@@ -413,7 +413,7 @@ func TestContextLibcStage4HelpersNilAndClosedGuards(t *testing.T) {
 	require.Nil(t, nilCtx.NewSymbol("x"))
 	require.Nil(t, nilCtx.NewGlobalSymbol("x"))
 	require.False(t, nilCtx.SetImportMeta(nil, false, false))
-	require.False(t, BootstrapBJSON(nilCtx))
+	require.False(t, nilCtx.BootstrapBJSON())
 	require.Equal(t, -1, nilCtx.LoopOnce())
 	require.Equal(t, -1, nilCtx.PollIO(1))
 	require.NotPanics(t, func() { nilCtx.DumpError() })
@@ -432,7 +432,7 @@ func TestContextLibcStage4HelpersNilAndClosedGuards(t *testing.T) {
 	require.Nil(t, ctx.NewSymbol("x"))
 	require.Nil(t, ctx.NewGlobalSymbol("x"))
 	require.False(t, ctx.SetImportMeta(moduleFunc, false, false))
-	require.False(t, BootstrapBJSON(ctx))
+	require.False(t, ctx.BootstrapBJSON())
 	require.Equal(t, -1, ctx.LoopOnce())
 	require.Equal(t, -1, ctx.PollIO(1))
 	require.NotPanics(t, func() { ctx.DumpError() })

--- a/runtime.go
+++ b/runtime.go
@@ -1055,8 +1055,8 @@ func applyIntrinsics(ctxRef *C.JSContext, set IntrinsicSet) bool {
 		applyStep("DOMException", set.DOMException, func() C.int { return C.JS_AddIntrinsicDOMException(ctxRef) })
 }
 
-// BootstrapStdOS registers std/os modules for the given context.
-func BootstrapStdOS(ctx *Context) bool {
+// BootstrapStdOS registers std/os modules for the context.
+func (ctx *Context) BootstrapStdOS() bool {
 	if runtimeBootstrapStdOSHook != nil {
 		return runtimeBootstrapStdOSHook(ctx)
 	}
@@ -1088,7 +1088,7 @@ func initStdOSModules(ctx *Context, stdModuleName *C.char, osModuleName *C.char)
 }
 
 // BootstrapTimers injects setTimeout/clearTimeout into globalThis.
-func BootstrapTimers(ctx *Context) bool {
+func (ctx *Context) BootstrapTimers() bool {
 	if runtimeBootstrapTimersHook != nil {
 		return runtimeBootstrapTimersHook(ctx)
 	}
@@ -1146,11 +1146,11 @@ func (r *Runtime) NewContextWithOptions(opts ...ContextBootstrapOption) *Context
 	registerContext(ctx_ref, ctx)
 	r.registerOwnedContext(ctx)
 
-	if bootstrap.loadStdOS && !BootstrapStdOS(ctx) {
+	if bootstrap.loadStdOS && !ctx.BootstrapStdOS() {
 		ctx.Close()
 		return nil
 	}
-	if bootstrap.injectTimers && !BootstrapTimers(ctx) {
+	if bootstrap.injectTimers && !ctx.BootstrapTimers() {
 		ctx.Close()
 		return nil
 	}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -1235,15 +1235,15 @@ func TestRuntimeContextBootstrapOptions(t *testing.T) {
 	bareCtx := rt.NewBareContext()
 	require.NotNil(t, bareCtx)
 	require.Equal(t, "undefined", typeOfSetTimeout(bareCtx))
-	require.True(t, BootstrapStdOS(bareCtx))
-	require.True(t, BootstrapTimers(bareCtx))
+	require.True(t, bareCtx.BootstrapStdOS())
+	require.True(t, bareCtx.BootstrapTimers())
 	require.Equal(t, "function", typeOfSetTimeout(bareCtx))
 	bareCtx.Close()
 
 	minimalCtx := rt.NewContextWithOptions(MinimalBootstrap())
 	require.NotNil(t, minimalCtx)
 	require.Equal(t, "undefined", typeOfSetTimeout(minimalCtx))
-	require.True(t, BootstrapTimers(minimalCtx))
+	require.True(t, minimalCtx.BootstrapTimers())
 	require.Equal(t, "function", typeOfSetTimeout(minimalCtx))
 	minimalCtx.Close()
 
@@ -1264,8 +1264,9 @@ func TestRuntimeContextBootstrapOptions(t *testing.T) {
 }
 
 func TestRuntimeContextBootstrapFailClosedAfterClose(t *testing.T) {
-	require.False(t, BootstrapStdOS(nil))
-	require.False(t, BootstrapTimers(nil))
+	var nilCtx *Context
+	require.False(t, nilCtx.BootstrapStdOS())
+	require.False(t, nilCtx.BootstrapTimers())
 
 	rt := NewRuntime()
 	defer rt.Close()
@@ -1274,8 +1275,8 @@ func TestRuntimeContextBootstrapFailClosedAfterClose(t *testing.T) {
 	require.NotNil(t, ctx)
 	ctx.Close()
 
-	require.False(t, BootstrapStdOS(ctx))
-	require.False(t, BootstrapTimers(ctx))
+	require.False(t, ctx.BootstrapStdOS())
+	require.False(t, ctx.BootstrapTimers())
 }
 
 func TestRuntimeContextBootstrapOwnerDenied(t *testing.T) {
@@ -1298,8 +1299,8 @@ func TestRuntimeContextBootstrapOwnerDenied(t *testing.T) {
 	require.NotNil(t, ctx)
 
 	gid.Store(72)
-	require.False(t, BootstrapStdOS(ctx))
-	require.False(t, BootstrapTimers(ctx))
+	require.False(t, ctx.BootstrapStdOS())
+	require.False(t, ctx.BootstrapTimers())
 
 	gid.Store(71)
 	ctx.Close()
@@ -1347,12 +1348,12 @@ func TestRuntimeBootstrapStdOSInitHook(t *testing.T) {
 	runtimeBootstrapStdOSInitHook = func(_ *Context) (bool, bool) {
 		return true, false
 	}
-	require.False(t, BootstrapStdOS(ctx))
+	require.False(t, ctx.BootstrapStdOS())
 
 	runtimeBootstrapStdOSInitHook = func(_ *Context) (bool, bool) {
 		return true, true
 	}
-	require.True(t, BootstrapStdOS(ctx))
+	require.True(t, ctx.BootstrapStdOS())
 }
 
 func TestRuntimeContextBootstrapStressContract(t *testing.T) {
@@ -1364,8 +1365,8 @@ func TestRuntimeContextBootstrapStressContract(t *testing.T) {
 		require.NotNil(t, ctx)
 
 		if i%2 == 0 {
-			require.True(t, BootstrapStdOS(ctx))
-			require.True(t, BootstrapTimers(ctx))
+			require.True(t, ctx.BootstrapStdOS())
+			require.True(t, ctx.BootstrapTimers())
 		}
 
 		result := ctx.Eval(`1 + 1`)

--- a/value.go
+++ b/value.go
@@ -974,6 +974,7 @@ func (v *Value) IsString() bool        { return v != nil && bool(C.JS_IsString(v
 func (v *Value) IsSymbol() bool        { return v != nil && bool(C.JS_IsSymbol(v.ref)) }
 func (v *Value) IsObject() bool        { return v != nil && bool(C.JS_IsObject(v.ref)) }
 func (v *Value) IsArray() bool         { return v != nil && bool(C.JS_IsArray(v.ref)) }
+func (v *Value) IsDate() bool          { return v != nil && bool(C.JS_IsDate(v.ref)) }
 func (v *Value) IsError() bool         { return v != nil && bool(C.JS_IsError(v.ref)) }
 func (v *Value) IsFunction() bool      { return v != nil && bool(C.JS_IsFunction(v.ctx.ref, v.ref)) }
 func (v *Value) IsConstructor() bool   { return v != nil && bool(C.JS_IsConstructor(v.ctx.ref, v.ref)) }

--- a/value_test.go
+++ b/value_test.go
@@ -196,6 +196,28 @@ func TestValueObjectControlAPIsInvalidReceiver(t *testing.T) {
 	require.False(t, nilValue.SetPrototype(nil))
 }
 
+func TestValueIsDateAPI(t *testing.T) {
+	useStableOwnerHooksForLegacySubtests(t)
+
+	rt := NewRuntime()
+	defer rt.Close()
+	ctx := rt.NewContext()
+	defer ctx.Close()
+
+	date := ctx.NewDate(1700000000000)
+	require.NotNil(t, date)
+	defer date.Free()
+	require.True(t, date.IsDate())
+
+	str := ctx.NewString("not-date")
+	require.NotNil(t, str)
+	defer str.Free()
+	require.False(t, str.IsDate())
+
+	var nilValue *Value
+	require.False(t, nilValue.IsDate())
+}
+
 func TestValuePropertyDescriptorAndAtomInt64APIs(t *testing.T) {
 	useStableOwnerHooksForLegacySubtests(t)
 


### PR DESCRIPTION
- add DumpError, LoopOnce, PollIO, NewDate, NewSymbol, NewGlobalSymbol
- add SetImportMeta and BootstrapBJSON context helpers
- add Value.IsDate
- add comprehensive Stage 4 tests with fail-closed coverage